### PR TITLE
Trigger tests and (de) serialization test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+src/dservConfig.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(dserv VERSION 1.3)
 

--- a/api/dservapi.c
+++ b/api/dservapi.c
@@ -71,12 +71,13 @@ dservapi_get_from_dataserver(int fd,
   char cmd[] = "<";
   int bufsize;
   int rval;
-  uint16_t varlen = strlen(varname);
+
+  uint16_t name_length = strlen(varname);
   
   struct iovec iov[3];
   iov[0].iov_base = cmd;
   iov[0].iov_len = strlen(cmd);
-  iov[1].iov_base = (void *) &varlen;
+  iov[1].iov_base = (void *) &name_length;
   iov[1].iov_len = sizeof(uint16_t);
   iov[2].iov_base = (void *) varname;
   iov[2].iov_len = strlen(varname);
@@ -117,18 +118,18 @@ int dservapi_write_to_dataserver(int fd,
   uint8_t cmd = DPOINT_BINARY_MSG_CHAR;
   static char buf[DPOINT_BINARY_FIXED_LENGTH];
  
-  uint16_t varlen;
+  uint16_t name_length;
   uint64_t timestamp = 0;
   uint32_t datatype = dtype,  datalen = len;
 
   uint16_t bufidx = 0;
   uint16_t total_bytes = 0;
 
-  varlen = strlen(varname);
+  name_length = strlen(varname);
 
   // Start by seeing how much space we need
-  total_bytes += sizeof(uint16_t); // varlen
-  total_bytes += varlen;           // strlen(varname)
+  total_bytes += sizeof(uint16_t); // name_length
+  total_bytes += name_length;      // strlen(varname)
   total_bytes += sizeof(uint64_t); // timestamp
   total_bytes += sizeof(uint32_t); // datatype
   total_bytes += sizeof(uint32_t); // datalen
@@ -142,11 +143,11 @@ int dservapi_write_to_dataserver(int fd,
   memcpy(&buf[bufidx], &cmd, sizeof(uint8_t));
   bufidx += sizeof(uint8_t);
 
-  memcpy(&buf[bufidx], &varlen, sizeof(uint16_t));
+  memcpy(&buf[bufidx], &name_length, sizeof(uint16_t));
   bufidx += sizeof(uint16_t);
 
-  memcpy(&buf[bufidx], varname, varlen);
-  bufidx += varlen;
+  memcpy(&buf[bufidx], varname, name_length);
+  bufidx += name_length;
 
   memcpy(&buf[bufidx], &timestamp, sizeof(uint64_t));
   bufidx += sizeof(uint64_t);

--- a/processors/touch_windows.c
+++ b/processors/touch_windows.c
@@ -60,7 +60,7 @@ void *newProcessParams(void)
   // region updates
   p->status_dpoint.flags = 0;
   p->status_dpoint.varname = strdup("proc/touch_windows/status");
-  p->status_dpoint.varlen = strlen(p->status_dpoint.varname);
+  p->status_dpoint.varlen = strlen(p->status_dpoint.varname) + 1;
   p->status_dpoint.data.type = DSERV_SHORT;
   p->status_dpoint.data.len = 4*sizeof(uint16_t);
   p->status_dpoint.data.buf = malloc(p->status_dpoint.data.len);
@@ -68,7 +68,7 @@ void *newProcessParams(void)
   // parameter updates
   p->settings_dpoint.flags = 0;
   p->settings_dpoint.varname = strdup("proc/touch_windows/settings");
-  p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname);
+  p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname) + 1;
   p->settings_dpoint.data.type = DSERV_SHORT;
   p->settings_dpoint.data.len = sizeof(window_settings_t);
   p->settings_dpoint.data.buf = malloc(p->settings_dpoint.data.len);
@@ -171,13 +171,13 @@ int setProcessParams(dpoint_process_param_setting_t *pinfo)
     if (p->status_dpoint.varname) free(p->status_dpoint.varname);
     p->status_dpoint.varname = malloc(strlen(vals[0])+2+strlen(status_str));
     sprintf(p->status_dpoint.varname, "%s/%s", vals[0], status_str);
-    p->status_dpoint.varlen = strlen(p->status_dpoint.varname);
+    p->status_dpoint.varlen = strlen(p->status_dpoint.varname) + 1;
 
     /* params */
     if (p->settings_dpoint.varname) free(p->settings_dpoint.varname);
     p->settings_dpoint.varname = malloc(strlen(vals[0])+2+strlen(params_str));
     sprintf(p->settings_dpoint.varname, "%s/%s", vals[0], params_str);
-    p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname);
+    p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname) + 1;
 
     return DPOINT_PROCESS_IGNORE;
   }

--- a/processors/windows.c
+++ b/processors/windows.c
@@ -66,7 +66,7 @@ void *newProcessParams(void)
   // region updates
   p->status_dpoint.flags = 0;
   p->status_dpoint.varname = strdup("proc/windows/status");
-  p->status_dpoint.varlen = strlen(p->status_dpoint.varname);
+  p->status_dpoint.varlen = strlen(p->status_dpoint.varname) + 1;
   p->status_dpoint.data.type = DSERV_SHORT;
   p->status_dpoint.data.len = 4*sizeof(uint16_t);
   p->status_dpoint.data.buf = malloc(p->status_dpoint.data.len);
@@ -74,7 +74,7 @@ void *newProcessParams(void)
   // parameter updates
   p->settings_dpoint.flags = 0;
   p->settings_dpoint.varname = strdup("proc/windows/settings");
-  p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname);
+  p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname) + 1;
   p->settings_dpoint.data.type = DSERV_SHORT;
   p->settings_dpoint.data.len = sizeof(window_settings_t);
   p->settings_dpoint.data.buf = malloc(p->settings_dpoint.data.len);
@@ -177,13 +177,13 @@ int setProcessParams(dpoint_process_param_setting_t *pinfo)
     if (p->status_dpoint.varname) free(p->status_dpoint.varname);
     p->status_dpoint.varname = malloc(strlen(vals[0])+2+strlen(status_str));
     sprintf(p->status_dpoint.varname, "%s/%s", vals[0], status_str);
-    p->status_dpoint.varlen = strlen(p->status_dpoint.varname);
+    p->status_dpoint.varlen = strlen(p->status_dpoint.varname) + 1;
 
     /* params */
     if (p->settings_dpoint.varname) free(p->settings_dpoint.varname);
     p->settings_dpoint.varname = malloc(strlen(vals[0])+2+strlen(params_str));
     sprintf(p->settings_dpoint.varname, "%s/%s", vals[0], params_str);
-    p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname);
+    p->settings_dpoint.varlen = strlen(p->settings_dpoint.varname) + 1;
     return DPOINT_PROCESS_IGNORE;
   }
 

--- a/src/Dataserver.cpp
+++ b/src/Dataserver.cpp
@@ -2106,6 +2106,8 @@ Dataserver::tcp_client_process(Dataserver *ds, int sockfd)
 	      buf[1] == 's' && buf[2] == 'e' &&
 	      buf[3] == 't' && buf[4] == ' ')
 	    {
+        // set varlen datatype datalen
+        // The client should send varlen as strlen(varname) + 1;
 	      if (sscanf(&buf[5], "%d %d %d", &varlen,
 			 &datatype, &datalen) != 3)
 		goto close_up;
@@ -2114,8 +2116,11 @@ Dataserver::tcp_client_process(Dataserver *ds, int sockfd)
 	      // Acknowledge to prevent buffering on sender side
 	      rval = write(sockfd, newline_buf, 1); 
 
+        // varlen should be strlen(varname) + 1;
 	      varname = (char *) malloc(varlen);
+        // TODO: should we read (varlen - 1) bytes rather than varlen bytes?
 	      doRead(sockfd, varname, varlen);
+        // TODO; should we set the null terminator at index varlen - 1?
 	      varname[varlen - 2] = '\0';
 	      
 	      //	      std::cerr << "point name: " << varname << std::endl;
@@ -2187,14 +2192,19 @@ Dataserver::tcp_client_process(Dataserver *ds, int sockfd)
 		   buf[3] == 't' && buf[4] == ' ')
 	    {
 
+        // get varlen
+        // The client should send varlen as strlen(varname) + 1;
 	      if (sscanf(&buf[5], "%d", &varlen) != 1)
 		goto close_up;
 	      
 	      // Acknowledge to prevent buffering on sender side
 	      rval = write(sockfd, newline_buf, 1);
 
+        // varlen should be strlen(varname) + 1;
 	      varname = (char *) malloc(varlen);
+        // TODO: should we read (varlen - 1) bytes rather than varlen bytes?
 	      doRead(sockfd, varname, varlen);
+        // TODO; should we set the null terminator at index varlen - 1?
 	      varname[varlen - 2] = '\0';
 	      
 	      rc = ds->get(varname, &dpoint);

--- a/src/Dataserver.cpp
+++ b/src/Dataserver.cpp
@@ -1066,7 +1066,7 @@ static int process_requests(Dataserver *dserv) {
 	/* name of dpoint (special for DSERV_EVTs */
 	if (dpoint->data.e.dtype != DSERV_EVT) {
 	  /* point name */
-	  commandArray[1] = Tcl_NewStringObj(dpoint->varname, dpoint->varlen);
+	  commandArray[1] = Tcl_NewStringObj(dpoint->varname, strlen(dpoint->varname));
 	  /* data as Tcl_Obj */
 	  commandArray[2] = dpoint_to_tclobj(interp, dpoint);
 	}

--- a/src/Dataserver.cpp
+++ b/src/Dataserver.cpp
@@ -93,9 +93,12 @@ ds_datapoint_t *Dataserver::process(ds_datapoint_t *dpoint)
 
 void Dataserver::trigger(ds_datapoint_t *dpoint)
 {
-  if (trigger_matches.is_match(dpoint->varname)) {
+  // Datapoint names can match patterns exactly or via wildcards like * or ?.
+  MatchSpec *match = trigger_matches.find_match(dpoint->varname);
+  if (match) {
     std::string script;
-    if (trigger_scripts.find(dpoint->varname, script)) {
+    // Scripts are keyed by pattern -- use the matching pattern for the datapoint name.
+    if (trigger_scripts.find(match->matchstr.c_str(), script)) {
       client_request_t client_request;
       client_request.type = REQ_TRIGGER;
       client_request.script = std::move(script);

--- a/src/LogClient.cpp
+++ b/src/LogClient.cpp
@@ -229,11 +229,12 @@ int LogClient::write_dpoint(ds_datapoint_t *dpoint)
 	 dpoint->data.e.dtype, dpoint->flags, dpoint->data.len);
 #endif
   
-  if (write(fd, &dpoint->varlen, sizeof(uint16_t)) != sizeof(uint16_t))
+  // datapoint varlen includes the NULL terminator, write only the characters before that.
+  uint16_t name_length = dpoint->varlen - 1;
+  if (write(fd, &name_length, sizeof(uint16_t)) != sizeof(uint16_t))
     goto write_error;
-  
-  if (write(fd, dpoint->varname, (int) dpoint->varlen) !=
-      (int) dpoint->varlen)
+
+  if (write(fd, dpoint->varname, (int) name_length) != (int) name_length)
     goto write_error;
   
   if (write(fd, &dpoint->timestamp, sizeof(uint64_t)) != sizeof(uint64_t))

--- a/src/MatchDict.h
+++ b/src/MatchDict.h
@@ -255,10 +255,11 @@ class MatchDict
   }
 
   // check all match specs for a match
+  // return the last match, if any
   // need to check all of them to ensure alert_every counter is updated
-  bool is_match(char *var)
+  MatchSpec *find_match(char *var)
   {
-    bool ret = false;
+    MatchSpec *ret = NULL;
     for (auto&& it : map_) {
       MatchSpec *match = &it.second;
       if (!match->active) continue;
@@ -267,12 +268,12 @@ class MatchDict
       case MatchSpec::MATCH_EXACT:
 	if (!strcmp(var, match->matchstr.c_str()) &&
 	    !(match->count++ % match->alert_every))
-	  ret = true;
+	  ret = match;
 	break;
       case MatchSpec::MATCH_KRAUSS:
 	if (FastWildCompare((char *) match->matchstr.c_str(), var) &&
 	    !(match->count++ % match->alert_every))
-	  ret = true;
+	  ret = match;
 	break;
       case MatchSpec::MATCH_BEGIN:
       case MatchSpec::MATCH_END:

--- a/src/SendTable.h
+++ b/src/SendTable.h
@@ -71,7 +71,7 @@ class SendTable
       if (!send_client->active) {
 	close_vec.push_back(send_client);
       }
-      else if (send_client->matches.is_match(dpoint->varname)) {
+      else if (send_client->matches.find_match(dpoint->varname)) {
 	ds_datapoint_t *dp = dpoint_copy(dpoint);
 	send_client->dpoint_queue.push_back(dp);
       }

--- a/src/TclServer.cpp
+++ b/src/TclServer.cpp
@@ -589,8 +589,7 @@ static int dpoint_tcl_script(Tcl_Interp *interp,
 	  
   /* name of dpoint (special for DSERV_EVTs */
   if (dpoint->data.e.dtype != DSERV_EVT) {
-    commandArray[1] = Tcl_NewStringObj(dpoint->varname,
-				       dpoint->varlen-1);
+    commandArray[1] = Tcl_NewStringObj(dpoint->varname, dpoint->varlen-1);
     /* data as Tcl_Obj */
     commandArray[2] = dpoint_to_tclobj(interp, dpoint);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,8 +24,20 @@ Exiting dserv instead of waiting for messages.
 Shutting down..."
 )
 
+# Obtain GoogleTest for testing C++ code.
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
 # Run a unit test for datapoint serialization and deserialization.
 include_directories("${CMAKE_SOURCE_DIR}/src")
 add_executable(datapoint_serialization "datapoint_serialization.cpp" "${CMAKE_SOURCE_DIR}/src/Datapoint.c" "${CMAKE_SOURCE_DIR}/src/Base64.c")
-target_link_libraries(datapoint_serialization ${LIBJANSSON})
-add_test(datapoint_serialization datapoint_serialization)
+target_link_libraries(datapoint_serialization ${LIBJANSSON} GTest::gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(datapoint_serialization)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,29 @@ Exiting dserv instead of waiting for messages.
 Shutting down..."
 )
 
+# Write datapoints to dsserv.log.
+add_test(
+    NAME logger_script
+    COMMAND dserv --exit --cscript "${CMAKE_SOURCE_DIR}/tests/test_logger.tcl"
+)
+set_property(TEST logger_script PROPERTY PASS_REGULAR_EXPRESSION "\
+Start logger test.
+End logger test.
+Exiting dserv instead of waiting for messages.
+Shutting down..."
+)
+
+# Expect in dsserv.log:
+# - starts with dslog
+# - datapont test/foo with timestamp "B" (ASCII 66) and value 66
+# - datapont test/foo with timestamp "D" (ASCII 68) and value 68
+add_test(
+    NAME logger_output
+    COMMAND xxd -c 100 dserv.log
+)
+set_property(TEST logger_output PROPERTY DEPENDS logger_script)
+set_property(TEST logger_output PROPERTY PASS_REGULAR_EXPRESSION "dslog.*test/fooB.*66..test/fooD.*68")
+
 # Obtain GoogleTest for testing C++ code.
 include(FetchContent)
 FetchContent_Declare(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,3 +9,16 @@ add_test(
     COMMAND dserv --help
 )
 set_property(TEST help PROPERTY PASS_REGULAR_EXPRESSION "Data server")
+
+add_test(
+    NAME trigger_script_foo
+    COMMAND dserv --exit --tscript ../../tests/test_triggers.tcl
+)
+set_property(TEST trigger_script_foo PROPERTY PASS_REGULAR_EXPRESSION "Handle test/foo: event = 42, latest = 42")
+
+
+add_test(
+    NAME trigger_script_bar
+    COMMAND dserv --exit --tscript ../../tests/test_triggers.tcl
+)
+set_property(TEST trigger_script_bar PROPERTY PASS_REGULAR_EXPRESSION "Handle test/bar: event = 43, latest = 44")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,11 +12,15 @@ set_property(TEST help PROPERTY PASS_REGULAR_EXPRESSION "Data server")
 
 add_test(
     NAME trigger_script
-    COMMAND dserv --exit --tscript ../../tests/test_triggers.tcl
+    COMMAND dserv --exit --tscript "${CMAKE_SOURCE_DIR}/tests/test_triggers.tcl"
 )
 set_property(
     TEST trigger_script
     PROPERTY PASS_REGULAR_EXPRESSION "\
+Start trigger test.
+End trigger test.
 Handle test/foo: event = 42, latest = 42
-Handle test/bar: event = 43, latest = 44"
+Handle test/bar: event = 43, latest = 44
+Exiting dserv instead of waiting for messages.
+Shutting down..."
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,9 +14,7 @@ add_test(
     NAME trigger_script
     COMMAND dserv --exit --tscript "${CMAKE_SOURCE_DIR}/tests/test_triggers.tcl"
 )
-set_property(
-    TEST trigger_script
-    PROPERTY PASS_REGULAR_EXPRESSION "\
+set_property(TEST trigger_script PROPERTY PASS_REGULAR_EXPRESSION "\
 Start trigger test.
 End trigger test.
 Handle test/foo: event = 42, latest = 42

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,14 +11,12 @@ add_test(
 set_property(TEST help PROPERTY PASS_REGULAR_EXPRESSION "Data server")
 
 add_test(
-    NAME trigger_script_foo
+    NAME trigger_script
     COMMAND dserv --exit --tscript ../../tests/test_triggers.tcl
 )
-set_property(TEST trigger_script_foo PROPERTY PASS_REGULAR_EXPRESSION "Handle test/foo: event = 42, latest = 42")
-
-
-add_test(
-    NAME trigger_script_bar
-    COMMAND dserv --exit --tscript ../../tests/test_triggers.tcl
+set_property(
+    TEST trigger_script
+    PROPERTY PASS_REGULAR_EXPRESSION "\
+Handle test/foo: event = 42, latest = 42
+Handle test/bar: event = 43, latest = 44"
 )
-set_property(TEST trigger_script_bar PROPERTY PASS_REGULAR_EXPRESSION "Handle test/bar: event = 43, latest = 44")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Run several end-to-end tests via the dserv executable, looking for expected std out.
 add_test(
     NAME not_an_option
     COMMAND dserv --not_an_option
@@ -22,3 +23,9 @@ Handle test/bar: event = 43, latest = 44
 Exiting dserv instead of waiting for messages.
 Shutting down..."
 )
+
+# Run a unit test for datapoint serialization and deserialization.
+include_directories("${CMAKE_SOURCE_DIR}/src")
+add_executable(datapoint_serialization "datapoint_serialization.cpp" "${CMAKE_SOURCE_DIR}/src/Datapoint.c" "${CMAKE_SOURCE_DIR}/src/Base64.c")
+target_link_libraries(datapoint_serialization ${LIBJANSSON})
+add_test(datapoint_serialization datapoint_serialization)

--- a/tests/datapoint_serialization.cpp
+++ b/tests/datapoint_serialization.cpp
@@ -1,64 +1,47 @@
-#include <iostream>
+#include <gtest/gtest.h>
 #include <stdio.h>
 #include <string.h>
 
+#include <iostream>
+
 #include "Datapoint.h"
 
-// Perhaps we should adopt Google Test, with handy assertions, for tests like this.
-// https://google.github.io/googletest/quickstart-cmake.html
+TEST(DatapointSerialization, RoundTrip) {
+  // Construct a sample datapoint.
+  char varname[] = "test/datapoint";
+  uint64_t timestmap = 42;
+  double data = 1234.4567;
+  ds_datapoint_t *datapoint = dpoint_new(
+      varname, timestmap, DSERV_DOUBLE, sizeof(double), (unsigned char *)&data);
 
-int main(int argc, char *argv[])
-{
-    // Construct a sample datapoint.
-    char varname[] = "test/datapoint";
-    uint64_t timestmap = 42;
-    double data = 1234.4567;
-    ds_datapoint_t *datapoint = dpoint_new(
-        varname,
-        timestmap,
-        DSERV_DOUBLE,
-        sizeof(double),
-        (unsigned char *)&data);
+  // By convention, datapoint varlen should be the length of varname, plus 1.
+  // This way the buffer includes the null terminator.
+  EXPECT_EQ(datapoint->varlen, strlen(varname) + 1);
+  EXPECT_STREQ(datapoint->varname, varname);
 
-    // By convention, datapoint varlen should be the length of varname, plus 1.
-    // This way the buffer includes the null terminator.
-    if(datapoint->varlen != strlen(varname) + 1)
-        exit(1);
-    if (strcmp(datapoint->varname, varname))
-        exit(1);
+  // Serialize, then deserialize the datapoint.
+  int buffer_size = dpoint_binary_size(datapoint);
+  unsigned char *buffer = (unsigned char *)malloc(buffer_size);
+  int serialized_size = dpoint_to_binary(datapoint, buffer, &buffer_size);
 
-    // Serialize, then deserialize the datapoint.
-    int buffer_size = dpoint_binary_size(datapoint);
-    unsigned char *buffer = (unsigned char *)malloc(buffer_size);
-    int serialized_size = dpoint_to_binary(datapoint, buffer, &buffer_size);
+  dpoint_free(datapoint);
 
-    if (buffer_size != serialized_size)
-        exit(1);
+  EXPECT_EQ(buffer_size, serialized_size);
 
-    ds_datapoint_t *datapoint_2 = dpoint_from_binary((char *)buffer, serialized_size);
+  ds_datapoint_t *datapoint_2 =
+      dpoint_from_binary((char *)buffer, serialized_size);
 
+  free(buffer);
 
-    // The deserialized datapoint should match the original.
-    if (strcmp(datapoint_2->varname, varname))
-        exit(1);
+  // The deserialized datapoint should match the original.
+  EXPECT_EQ(datapoint_2->varlen, strlen(varname) + 1);
+  EXPECT_STREQ(datapoint_2->varname, varname);
+  EXPECT_EQ(datapoint_2->timestamp, timestmap);
+  EXPECT_EQ(datapoint_2->data.type, DSERV_DOUBLE);
+  EXPECT_EQ(datapoint_2->data.len, sizeof(double));
 
-    if(datapoint_2->varlen != strlen(varname) + 1)
-        exit(1);
+  double data_2 = *(double *)(datapoint_2->data.buf);
+  EXPECT_EQ(data_2, data);
 
-    if(datapoint_2->timestamp != timestmap)
-        exit(1);
-
-    if(datapoint_2->data.type != DSERV_DOUBLE)
-        exit(1);
-
-    if(datapoint_2->data.len != sizeof(double))
-        exit(1);
-
-    double data_2 = *(double *)(datapoint_2->data.buf);
-    if(data_2 != data)
-        exit(1);
-
-    free(buffer);
-    dpoint_free(datapoint_2);
-    dpoint_free(datapoint);
+  dpoint_free(datapoint_2);
 }

--- a/tests/datapoint_serialization.cpp
+++ b/tests/datapoint_serialization.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+
+#include "Datapoint.h"
+
+// Perhaps we should adopt Google Test, with handy assertions, for tests like this.
+// https://google.github.io/googletest/quickstart-cmake.html
+
+int main(int argc, char *argv[])
+{
+    // Construct a sample datapoint.
+    char varname[] = "test/datapoint";
+    uint64_t timestmap = 42;
+    double data = 1234.4567;
+    ds_datapoint_t *datapoint = dpoint_new(
+        varname,
+        timestmap,
+        DSERV_DOUBLE,
+        sizeof(double),
+        (unsigned char *)&data);
+
+    // By convention, datapoint varlen should be the length of varname, plus 1.
+    // This way the buffer includes the null terminator.
+    if(datapoint->varlen != strlen(varname) + 1)
+        exit(1);
+    if (strcmp(datapoint->varname, varname))
+        exit(1);
+
+    // Serialize, then deserialize the datapoint.
+    int buffer_size = dpoint_binary_size(datapoint);
+    unsigned char *buffer = (unsigned char *)malloc(buffer_size);
+    int serialized_size = dpoint_to_binary(datapoint, buffer, &buffer_size);
+
+    if (buffer_size != serialized_size)
+        exit(1);
+
+    ds_datapoint_t *datapoint_2 = dpoint_from_binary((char *)buffer, serialized_size);
+
+
+    // The deserialized datapoint should match the original.
+    if (strcmp(datapoint_2->varname, varname))
+        exit(1);
+
+    if(datapoint_2->varlen != strlen(varname) + 1)
+        exit(1);
+
+    if(datapoint_2->timestamp != timestmap)
+        exit(1);
+
+    if(datapoint_2->data.type != DSERV_DOUBLE)
+        exit(1);
+
+    if(datapoint_2->data.len != sizeof(double))
+        exit(1);
+
+    double data_2 = *(double *)(datapoint_2->data.buf);
+    if(data_2 != data)
+        exit(1);
+
+    free(buffer);
+    dpoint_free(datapoint_2);
+    dpoint_free(datapoint);
+}

--- a/tests/test_logger.tcl
+++ b/tests/test_logger.tcl
@@ -1,0 +1,47 @@
+puts "Start logger test."
+
+# Create a log file, or truncate if it already exists.
+set logFile dserv.log
+dservLoggerOpen $logFile 1
+
+# Only write events matching pattern "test/*".
+dservLoggerAddMatch $logFile test/*
+
+# Set datapoints with fixed, known timestamps and integer datatype (5).
+# But this datapoint from before the logger is started should be ignored.
+dservSetData test/foo 65 5 65
+
+# Datapoints and logging commands flow through distinct queues and threads.
+# To test commands in order, wait several ms between them.
+set pause_ms 10
+
+# Log subsequent test/* events to file.
+after $pause_ms
+dservLoggerStart $logFile
+after $pause_ms
+dservSetData test/foo 66 5 66
+
+# Ignore events while logger is paused.
+after $pause_ms
+dservLoggerPause $logFile
+after $pause_ms
+dservSetData test/foo 67 5 67
+
+# Log subsequent test/* events, again.
+after $pause_ms
+dservLoggerResume $logFile
+after $pause_ms
+dservSetData test/foo 68 5 68
+
+# Ignore events that don't match the match pattern test/*.
+after $pause_ms
+dservSetData ignore/bar 69 5 69
+
+# Ignore events after logger is closed.
+after $pause_ms
+dservLoggerClose $logFile
+after $pause_ms
+dservSetData test/foo 70 5 70
+
+after $pause_ms
+puts "End logger test."

--- a/tests/test_triggers.tcl
+++ b/tests/test_triggers.tcl
@@ -5,7 +5,7 @@ proc test_handler { name data } {
     # Confirm we see expected values at the time of set and at the time of handling.
     # TODO: there's an unexpeted, non-printing character at the end of $name.
     # shell ignores this but ctest treats this like newline, breaking regex tests.
-    puts "Handle [string trim $name]: event = $data, latest = [dservGet $name]"
+    puts "Handle $name: event = $data, latest = [dservGet $name]"
 }
 
 triggerRemoveAll

--- a/tests/test_triggers.tcl
+++ b/tests/test_triggers.tcl
@@ -2,9 +2,7 @@ puts "Start trigger test."
 
 # This handler will be called by dserv when values "test/foo" and "test/bar" are set.
 proc test_handler { name data } {
-    # Confirm we see expected values at the time of set and at the time of handling.
-    # TODO: there's an unexpeted, non-printing character at the end of $name.
-    # shell ignores this but ctest treats this like newline, breaking regex tests.
+    # Print the value that was set as well as the current value at handling time.
     puts "Handle $name: event = $data, latest = [dservGet $name]"
 }
 
@@ -12,13 +10,12 @@ triggerRemoveAll
 dservSet test/foo 0
 dservSet test/bar 0
 
-# Bind our handler script to the value names we chose, to alert on every set (every 1 call).
-# TODO: can we register a handler with a wildcard?
-# triggerAdd test/* 1 test_handler
+# Bind our handler script to the value name test/foo and test/bar, to alert on "every 1" call ie always.
+# TODO: something amiss when registering handler with wildcard, as in triggerAdd test/* 1 test_handler
 triggerAdd test/foo 1 test_handler
 triggerAdd test/bar 1 test_handler
 
-# Expect sets 42 43 to trigger test_handler.
+# Expect sets 42 and 43 to trigger our test_handler.
 dservSet test/foo 42
 dservSet test/bar 43
 

--- a/tests/test_triggers.tcl
+++ b/tests/test_triggers.tcl
@@ -6,22 +6,21 @@ proc test_handler { name data } {
     puts "Handle $name: event = $data, latest = [dservGet $name]"
 }
 
+# Don't expect our handler to be triggered when initializing.
 triggerRemoveAll
 dservSet test/foo 0
 dservSet test/bar 0
 
 # Bind our handler script to the value name test/foo and test/bar, to alert on "every 1" call ie always.
-# TODO: something amiss when registering handler with wildcard, as in triggerAdd test/* 1 test_handler
-triggerAdd test/foo 1 test_handler
-triggerAdd test/bar 1 test_handler
+triggerAdd test/* 1 test_handler
 
 # Expect sets 42 and 43 to trigger our test_handler.
 dservSet test/foo 42
 dservSet test/bar 43
 
 # Don't expect set 44 to trigger test_handler.
-# However, the 44 will be visible to test_handler via dservGet.
-triggerRemove test/bar
+# However, the value 44 will be visible to test_handler via dservGet.
+triggerRemove test/*
 dservSet test/bar 44
 
 puts "End trigger test."

--- a/tests/test_triggers.tcl
+++ b/tests/test_triggers.tcl
@@ -11,7 +11,8 @@ triggerRemoveAll
 dservSet test/foo 0
 dservSet test/bar 0
 
-# Bind our handler script to the value name test/foo and test/bar, to alert on "every 1" call ie always.
+# Register our handler script to match datapoint names like test/foo and test/bar.
+# Register to alert on "every 1" change -- ie always.
 triggerAdd test/* 1 test_handler
 
 # Expect sets 42 and 43 to trigger our test_handler.

--- a/tests/test_triggers.tcl
+++ b/tests/test_triggers.tcl
@@ -1,0 +1,30 @@
+puts "Start trigger test."
+
+# This handler will be called by dserv when values "test/foo" and "test/bar" are set.
+proc test_handler { name data } {
+    # Confirm we see expected values at the time of set and at the time of handling.
+    # TODO: there's an unexpeted, non-printing character at the end of $name.
+    # shell ignores this but ctest treats this like newline, breaking regex tests.
+    puts "Handle [string trim $name]: event = $data, latest = [dservGet $name]"
+}
+
+triggerRemoveAll
+dservSet test/foo 0
+dservSet test/bar 0
+
+# Bind our handler script to the value names we chose, to alert on every set (every 1 call).
+# TODO: can we register a handler with a wildcard?
+# triggerAdd test/* 1 test_handler
+triggerAdd test/foo 1 test_handler
+triggerAdd test/bar 1 test_handler
+
+# Expect sets 42 43 to trigger test_handler.
+dservSet test/foo 42
+dservSet test/bar 43
+
+# Don't expect set 44 to trigger test_handler.
+# However, the 44 will be visible to test_handler via dservGet.
+triggerRemove test/bar
+dservSet test/bar 44
+
+puts "End trigger test."


### PR DESCRIPTION
Hi @sheinb, here is a PR with a Tcl-based test for basic trigger functionality, plus a few other things I found while writing the test.  I'll put a narrative summary here and specific comments in the diff view, below.

I wrote [tests/test_triggers.tcl](https://github.com/SheinbergLab/dserv/compare/main...benjamin-heasly:dserv:tcl-tests?expand=1#diff-8b50a5ce48ace3268ea05a3896e5079945b21ee2d7f40bf6804e55d8e36e7f6e) to cover the basic pub-sub functionality of triggers and Tcl script callbacks.  `ctest` can call `dserv` with this script, then assert correctness of standard out.

To make it easier to run tests like this I added an `--exit` option to `dserv` to exit right away instead of waiting for clients to connect and do things.  I think this flows through orderly shutdown code that you already wrote.

While writing assertions to match standard out, I noticed `ctest` reporting unexpected line breaks in some of the strings I `puts`-ed.  I traced the issue to an extra null terminator in the strings passed as  `name` to trigger callback scripts.  The shell ignores this extra null, hiding the issue.  But `ctest` turned it into a new line, breaking assertions.

So, I reviewed the `dserv` repo for usage of datapoint `varname` and `varlen`, hoping to make the interpretation consistent.  I think this looks good now, but I'm new to the code and curious what you think.  Especially for serialization and deserializtion, will this change break existing client code?  If so maybe we can decide what's correct and/or clarify some naming and interpretation.

Because I changed serialization and deserialization code, I wrote [tests/datapoint_serialization.cpp](https://github.com/SheinbergLab/dserv/compare/main...benjamin-heasly:dserv:tcl-tests?expand=1#diff-c1c49fde3926b4ce75f215df189047f5d3ad75d3eb699e9d386d5a0712a1f826) to serialize and deserialize a datapoint.  Maybe we'll want a few focused unit tests like this, in addition to Tcl-based tests that use the front door.

Finally, I wanted to register a datapoint trigger using a wildcard like `test/*`, but got confused that the callback script was never called.  It looks like the lookup for callback script was using the datapoint name, rather than the registered match pattern.  So even when a datapoint matched a wildcard, no callback script was found.  I changed `Dataserver` to look up scripts by registered pattern instead of datapoint name.  Did I get this to work as intended, or did I screw things up?

I'm sorry this PR has changes in a few areas.  I think the unifying theme is to have  [tests/test_triggers.tcl](https://github.com/SheinbergLab/dserv/compare/main...benjamin-heasly:dserv:tcl-tests?expand=1#diff-8b50a5ce48ace3268ea05a3896e5079945b21ee2d7f40bf6804e55d8e36e7f6e) demonstrate intended trigger functionality, and be able to run it with automated assertions.

I'm happy to revise, replace, rethink this PR however seems good and/or chat about it on Zoom!