### PR TITLE
Configure entitlements for essgui

### DIFF
--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -196,7 +196,7 @@ jobs:
           # Log info about this keychain for debuging.
           security find-identity -p basic -v
 
-      - name: Build, sign, package, and notarize dserv.
+      - name: Build, sign, package, and notarize essgui.
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}

--- a/tools/essgui/CMakeLists.txt
+++ b/tools/essgui/CMakeLists.txt
@@ -124,7 +124,7 @@ elseif(APPLE)
 
         # "Fixing up" the app bundle invalidates previously signed binaries.
         # Go back and sign things again: the executable, any relocated dylibs, and the bundle itself.
-        set(CODESIGN_COMMAND /usr/bin/codesign --force --verify ${CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS} --sign)
+        set(CODESIGN_COMMAND /usr/bin/codesign --force --verify ${CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS} --entitlements ${CMAKE_SOURCE_DIR}/macos/essgui.entitlements --sign)
         install(
             CODE "file(GLOB BUNDLE_DYLIBS ${APP_BUNDLE}/Contents/Frameworks/*.dylib)"
             CODE "execute_process(COMMAND ${CODESIGN_COMMAND} \"${CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY}\" \$\{BUNDLE_DYLIBS\})"

--- a/tools/essgui/macos/essgui.entitlements
+++ b/tools/essgui/macos/essgui.entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- Library validation would prevent dserv from loading libtcl at runtime. -->
+    <!-- Library validation would prevent essgui from loading dylibs from dlsh.zip. -->
     <!-- We can still pass the Apple notarization checks without library validation. -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>


### PR DESCRIPTION
Hi @sheinb, here's how I've been configuring entitlements for our executables -- so far just to disable strict library validation (that Team ID error).

For simple builds it seems cmake can apply the entitlements for us, when it does code signing.  But for app bundles it seems like we need to re-sign everything after the executable and dylibs have been bundled and reconfigured to look for each other within the bundle.  At that point it's easier just to add `--entitlements` to our own `codesign` command.