### PR TITLE
Add Loader Editor tab to ESS Workbench

### DIFF
--- a/www/css/ess_workbench.css
+++ b/www/css/ess_workbench.css
@@ -2049,3 +2049,390 @@ body {
         display: none;
     }
 }
+
+/* ==========================================
+   Loaders Editor Tab
+   ========================================== */
+
+.loaders-editor {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: var(--wb-space-md);
+}
+
+/* Toolbar */
+.loaders-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--wb-space-sm) var(--wb-space-md);
+    background: var(--wb-bg-secondary);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-md);
+    margin-bottom: var(--wb-space-md);
+    gap: var(--wb-space-sm);
+    flex-wrap: wrap;
+}
+
+.loaders-toolbar-left,
+.loaders-toolbar-right {
+    display: flex;
+    align-items: center;
+    gap: var(--wb-space-xs);
+}
+
+.loaders-selector {
+    display: flex;
+    align-items: center;
+    gap: var(--wb-space-sm);
+}
+
+.loaders-selector-label {
+    font-size: 0.875rem;
+    color: var(--wb-text-secondary);
+}
+
+.loader-select {
+    padding: 0.5rem 1rem;
+    background: var(--wb-bg-input);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-sm);
+    color: var(--wb-text);
+    font-size: 0.9375rem;
+    font-weight: 500;
+    min-width: 200px;
+    cursor: pointer;
+}
+
+.loader-select:focus {
+    outline: none;
+    border-color: var(--wb-accent);
+}
+
+.loaders-run-status {
+    font-size: 0.75rem;
+    color: var(--wb-text-muted);
+    margin-left: var(--wb-space-xs);
+}
+
+.loaders-run-status.success { color: var(--wb-success); }
+.loaders-run-status.error { color: var(--wb-error); }
+
+.loaders-validation-status {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: var(--wb-radius-sm);
+}
+
+.loaders-validation-status.valid {
+    color: var(--wb-success);
+}
+
+.loaders-validation-status.error {
+    color: var(--wb-error);
+    background: rgba(239, 68, 68, 0.1);
+}
+
+.loaders-validation-status.warning {
+    color: var(--wb-warning);
+}
+
+/* Save button states */
+#loader-save-btn,
+#loader-save-reload-btn {
+    transition: all 0.2s;
+}
+
+#loader-save-btn:disabled,
+#loader-save-reload-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#loader-save-btn.modified,
+#loader-save-reload-btn.modified {
+    background: var(--wb-accent);
+    color: white;
+    opacity: 1;
+}
+
+/* Run button */
+#loader-run-btn {
+    background: var(--wb-success, #22c55e);
+    color: white;
+    border-color: var(--wb-success, #22c55e);
+}
+
+#loader-run-btn:hover:not(:disabled) {
+    filter: brightness(1.1);
+}
+
+#loader-run-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Split view */
+.loaders-split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--wb-space-md);
+    flex: 1;
+    min-height: 0;
+}
+
+@media (min-width: 1600px) {
+    .loaders-split {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 1100px) {
+    .loaders-split {
+        grid-template-columns: 1fr 400px;
+    }
+}
+
+@media (max-width: 900px) {
+    .loaders-split {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Script Panel (Left) */
+.loaders-script-panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--wb-bg-secondary);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-md);
+    overflow: hidden;
+}
+
+.loader-editor-container {
+    flex: 1;
+    min-height: 0;
+}
+
+/* Results Panel (Right) */
+.loaders-result-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wb-space-md);
+    min-height: 0;
+}
+
+/* Arguments Panel */
+.loaders-args-panel {
+    background: var(--wb-bg-secondary);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-md);
+    flex-shrink: 0;
+    max-height: 250px;
+    overflow-y: auto;
+}
+
+.loaders-args-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--wb-space-xs) var(--wb-space-sm);
+    border-bottom: 1px solid var(--wb-border);
+}
+
+.loaders-args-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--wb-text-muted);
+}
+
+.loaders-args-body {
+    padding: var(--wb-space-sm);
+}
+
+.loaders-args-empty {
+    color: var(--wb-text-muted);
+    font-size: 0.8125rem;
+    font-style: italic;
+    padding: var(--wb-space-sm);
+    text-align: center;
+}
+
+/* Individual argument row */
+.loader-arg-row {
+    display: flex;
+    align-items: center;
+    gap: var(--wb-space-sm);
+    margin-bottom: var(--wb-space-xs);
+}
+
+.loader-arg-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8125rem;
+    color: var(--wb-accent);
+    min-width: 100px;
+    text-align: right;
+}
+
+.loader-arg-input {
+    flex: 1;
+    padding: 4px 8px;
+    background: var(--wb-bg-input);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-sm);
+    color: var(--wb-text);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8125rem;
+}
+
+.loader-arg-input:focus {
+    outline: none;
+    border-color: var(--wb-accent);
+}
+
+.loader-arg-options {
+    flex-shrink: 0;
+}
+
+.loader-arg-options select {
+    padding: 3px 6px;
+    background: var(--wb-bg-input);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-sm);
+    color: var(--wb-text-secondary);
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+/* Table Panel */
+.loaders-table-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: var(--wb-bg-secondary);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-md);
+    min-height: 200px;
+    overflow: hidden;
+}
+
+.loaders-table-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--wb-space-xs) var(--wb-space-sm);
+    border-bottom: 1px solid var(--wb-border);
+}
+
+.loaders-table-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--wb-text-muted);
+}
+
+.loaders-table-info {
+    font-size: 0.75rem;
+    color: var(--wb-text-muted);
+}
+
+.loaders-table-body {
+    flex: 1;
+    overflow: auto;
+}
+
+.loaders-table-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wb-space-sm);
+    height: 100%;
+    min-height: 150px;
+    color: var(--wb-text-muted);
+    font-size: 0.875rem;
+}
+
+.loaders-table-empty svg {
+    opacity: 0.3;
+}
+
+/* Console */
+.loaders-console {
+    background: var(--wb-bg-secondary);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-md);
+    margin-top: var(--wb-space-md);
+    max-height: 150px;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.loaders-console-header {
+    display: flex;
+    align-items: center;
+    gap: var(--wb-space-sm);
+    padding: var(--wb-space-xs) var(--wb-space-sm);
+    border-bottom: 1px solid var(--wb-border);
+}
+
+.loaders-console-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--wb-text-muted);
+}
+
+.loaders-console-count {
+    font-size: 0.6875rem;
+    color: var(--wb-error);
+}
+
+.loaders-console-actions {
+    margin-left: auto;
+}
+
+.loaders-console-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--wb-space-xs) var(--wb-space-sm);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+}
+
+.loader-console-entry {
+    padding: 2px 0;
+    border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+
+.loader-console-entry .time {
+    color: var(--wb-text-muted);
+    margin-right: var(--wb-space-xs);
+}
+
+.loader-console-entry .message {
+    color: var(--wb-text-secondary);
+}
+
+.loader-console-entry .message.error {
+    color: var(--wb-error);
+}
+
+.loader-console-entry .message.success {
+    color: var(--wb-success);
+}
+
+/* DGTableViewer dark theme overrides for workbench */
+.loaders-table-body .dg-table-viewer {
+    background: transparent;
+}
+
+.loaders-table-body .dg-header {
+    display: none; /* We have our own header */
+}

--- a/www/ess_workbench.html
+++ b/www/ess_workbench.html
@@ -11,6 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     
     <link rel="stylesheet" href="css/ess_workbench.css">
+    <link rel="stylesheet" href="css/DGTableViewer.css">
     <link rel="stylesheet" href="css/ess_workbench_registry.css">
     <link rel="stylesheet" href="css/ess_workbench_overlay.css">
     <style>
@@ -99,6 +100,15 @@
                         <line x1="17" y1="16" x2="23" y2="16"></line>
                     </svg>
                     Variants
+                </button>
+                <button class="tab-btn" data-tab="loaders">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                        <line x1="3" y1="9" x2="21" y2="9"></line>
+                        <line x1="3" y1="15" x2="21" y2="15"></line>
+                        <line x1="9" y1="3" x2="9" y2="21"></line>
+                    </svg>
+                    Loaders
                 </button>
                 <button class="tab-btn" data-tab="scripts">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -292,8 +302,124 @@
                         </div>
                     </div>
                 </div>
-            </div>	    
-	    
+            </div>
+
+            <!-- Loaders Tab -->
+            <div class="tab-content" id="tab-loaders">
+                <div class="loaders-editor">
+                    <!-- Mini Hero -->
+                    <div class="tab-hero">
+                        <div class="tab-hero-identity">
+                            <span class="tab-hero-project" id="loaders-hero-project">—</span>
+                            <span class="tab-hero-sep">/</span>
+                            <span class="tab-hero-system" id="loaders-hero-system">—</span>
+                            <span class="tab-hero-sep">/</span>
+                            <span class="tab-hero-protocol" id="loaders-hero-protocol">—</span>
+                        </div>
+                    </div>
+
+                    <!-- Toolbar -->
+                    <div class="loaders-toolbar">
+                        <div class="loaders-toolbar-left">
+                            <div class="loaders-selector">
+                                <label class="loaders-selector-label">Loader:</label>
+                                <select id="loader-select" class="loader-select">
+                                    <option value="">— select loader —</option>
+                                </select>
+                            </div>
+                            <button class="btn btn-sm" id="loader-run-btn" disabled>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polygon points="5 3 19 12 5 21 5 3"></polygon>
+                                </svg>
+                                Run
+                            </button>
+                            <span class="loaders-run-status" id="loader-run-status"></span>
+                        </div>
+                        <div class="loaders-toolbar-right">
+                            <div id="loader-overlay-controls"></div>
+                            <span class="loaders-validation-status" id="loader-validation-status"></span>
+                            <button class="btn btn-sm" id="loader-format-btn">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="21" y1="10" x2="3" y2="10"></line>
+                                    <line x1="21" y1="6" x2="3" y2="6"></line>
+                                    <line x1="21" y1="14" x2="3" y2="14"></line>
+                                    <line x1="21" y1="18" x2="3" y2="18"></line>
+                                </svg>
+                                Format
+                            </button>
+                            <div class="toolbar-divider"></div>
+                            <button class="btn btn-sm" id="loader-save-btn" disabled>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                                    <polyline points="17 21 17 13 7 13 7 21"></polyline>
+                                    <polyline points="7 3 7 8 15 8"></polyline>
+                                </svg>
+                                Save
+                            </button>
+                            <button class="btn btn-sm" id="loader-save-reload-btn" disabled>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="23 4 23 10 17 10"></polyline>
+                                    <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+                                </svg>
+                                Save &amp; Reload
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Split: Script Editor | Args + Table -->
+                    <div class="loaders-split">
+                        <!-- Script Editor (Left) -->
+                        <div class="loaders-script-panel">
+                            <div id="loader-script-editor" class="loader-editor-container"></div>
+                        </div>
+
+                        <!-- Results Panel (Right) -->
+                        <div class="loaders-result-panel">
+                            <!-- Arguments -->
+                            <div class="loaders-args-panel" id="loader-args-panel">
+                                <div class="loaders-args-header">
+                                    <span class="loaders-args-title">Arguments</span>
+                                    <button class="btn btn-xs" id="loader-args-reset-btn" title="Reset to defaults">Reset</button>
+                                </div>
+                                <div class="loaders-args-body" id="loader-args-body">
+                                    <div class="loaders-args-empty">Select a loader to see its arguments</div>
+                                </div>
+                            </div>
+
+                            <!-- Table Viewer -->
+                            <div class="loaders-table-panel">
+                                <div class="loaders-table-header">
+                                    <span class="loaders-table-title">stimdg</span>
+                                    <span class="loaders-table-info" id="loader-table-info"></span>
+                                </div>
+                                <div class="loaders-table-body" id="loader-table-container">
+                                    <div class="loaders-table-empty">
+                                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                                            <line x1="3" y1="9" x2="21" y2="9"></line>
+                                            <line x1="9" y1="3" x2="9" y2="21"></line>
+                                        </svg>
+                                        <span>Run a loader to see the trial table</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Console -->
+                    <div class="loaders-console" id="loader-console">
+                        <div class="loaders-console-header">
+                            <span class="loaders-console-title">Console</span>
+                            <span class="loaders-console-count" id="loader-error-count"></span>
+                            <div class="loaders-console-actions">
+                                <button class="btn btn-xs" id="loader-console-clear-btn">Clear</button>
+                            </div>
+                        </div>
+                        <div class="loaders-console-body" id="loader-console-output"></div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Scripts Tab -->
             <div class="tab-content" id="tab-scripts">
                 <!-- Mini Hero - simplified, no "Variant:" -->
@@ -665,6 +791,7 @@
     <script src="js/ws_manager.js"></script>
     <script src="js/DatapointManager.js"></script>
     <script src="js/registry_client.js"></script>
+    <script src="js/DGTableViewer.js"></script>
     <script src="js/ess_workbench.js"></script>
     <script src="js/ess_registry_plugin.js"></script>
     <script src="js/ess_overlay_plugin.js"></script>


### PR DESCRIPTION
## Summary

- Adds a new **Loaders** tab to the ESS Workbench for interactive development of loader procs (Tcl code that builds `stimdg` trial tables)
- Full TclEditor with loader parsing, argument editing, isolated sandbox execution, and DGTableViewer for result display
- Follows the same architectural patterns as the existing variant editor (overlay save, snapshot updates, split panel layout)

## Details

**HTML** (`ess_workbench.html`):
- New tab button with grid icon between Variants and Scripts
- Full `#tab-loaders` content section: toolbar, split editor/results layout, console panel
- DGTableViewer CSS/JS includes

**CSS** (`ess_workbench.css`):
- ~390 lines of loader-specific styles following existing workbench patterns
- Dark theme overrides for DGTableViewer

**JS** (`ess_workbench.js`):
- ~830 lines: initialization, sandbox management, script parsing, arg UI, run/save, formatting, console
- Isolated linked subprocess (`loader_dev`) for safe testing with `package require dlsh`
- Parses `$s add_loader` definitions to populate loader dropdown and extract argument names
- Cross-references variant `loader_options` to pre-populate argument values

## Test plan

- [ ] Verify new "Loaders" tab appears between Variants and Scripts
- [ ] Click Loaders tab — editor loads `loaders.tcl` content from snapshot
- [ ] Loader dropdown lists parsed loader names from the file
- [ ] Selecting a loader shows its argument fields
- [ ] "Run" executes in sandbox and displays stimdg table in DGTableViewer
- [ ] Save works through overlay system
- [ ] Errors in loader code appear in console panel
- [ ] Overlay plugin wiring for promote/discard (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)