### PR TITLE
Wire overlay plugin for loaders tab

### DIFF
--- a/www/js/ess_overlay_plugin.js
+++ b/www/js/ess_overlay_plugin.js
@@ -401,6 +401,7 @@ const OverlayPlugin = {
     _updateEditorOverlayControls(wb) {
         this._updateOverlayControlsFor(wb, 'scripts');
         this._updateOverlayControlsFor(wb, 'variants');
+        this._updateOverlayControlsFor(wb, 'loaders');
     },
 
     _updateOverlayControlsFor(wb, tab) {
@@ -412,6 +413,9 @@ const OverlayPlugin = {
         } else if (tab === 'variants') {
             containerId = 'variant-overlay-controls';
             scriptType = 'variants';
+        } else if (tab === 'loaders') {
+            containerId = 'loader-overlay-controls';
+            scriptType = 'loaders';
         } else {
             return;
         }


### PR DESCRIPTION
## Summary

- Extends the overlay plugin to support the new Loaders tab
- Adds promote/discard controls when the `loaders` script has an active overlay
- Injects into the existing `#loader-overlay-controls` placeholder in the loaders toolbar

## Changes

`www/js/ess_overlay_plugin.js` — 4 lines added:
- `_updateEditorOverlayControls()`: now also calls for `'loaders'`
- `_updateOverlayControlsFor()`: new `'loaders'` case mapping to `loader-overlay-controls` container with `scriptType = 'loaders'`

## Test plan

- [ ] Activate an overlay user, modify the loaders script, verify promote/discard buttons appear in the loaders toolbar
- [ ] Promote or discard the loaders overlay, verify controls update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)