### PR TITLE
Add module paths to loader sandbox for project packages

### DIFF
--- a/www/js/ess_workbench.js
+++ b/www/js/ess_workbench.js
@@ -2782,8 +2782,15 @@ class ESSWorkbench {
             this.loaderSandboxPrefix = this.loaderSandbox.getLinkedSubprocess();
 
             if (this.loaderSandboxPrefix) {
-                // Initialize with dlsh
+                // Initialize with dlsh and add module paths
                 await this.loaderSandbox.sendToLinked('package require dlsh');
+
+                // Add dserv lib and project-specific lib to module path
+                // so package require can find system packages (e.g., planko, points)
+                await this.loaderSandbox.sendToLinked(
+                    `::tcl::tm::add $::dspath/lib
+                     catch {::tcl::tm::add [send ess {set ::ess::system_path}]/[send ess {set ::ess::current(project)}]/lib}`
+                );
 
                 // Create dg_view proc for pushing tables
                 await this.loaderSandbox.sendToLinked(


### PR DESCRIPTION
## Summary

- Fixes `invalid command name "planko::generate_worlds"` and similar errors where project-specific packages aren't found in the sandbox
- Adds `$::dspath/lib` (core dserv modules) and the project-specific lib path to the sandbox's `tcl::tm` module path at init

## Details

The ESS process has project lib paths added during `set_project` (e.g., `systems/ess/planko/lib`), but the linked subprocess didn't inherit them. Now at sandbox init, after `package require dlsh`:

1. `::tcl::tm::add $::dspath/lib` — core dserv lib (always available)
2. `::tcl::tm::add [send ess {set ::ess::system_path}]/[send ess {set ::ess::current(project)}]/lib` — project-specific lib, queried from ESS process

## Test plan

- [ ] Run planko loader — `package require planko` should succeed
- [ ] Run search loader — `package require points` should still work
- [ ] Systems without project-specific libs should not error (catch wrapped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)