### PR TITLE
Parse variant option {label value} tuples correctly

### DIFF
--- a/www/js/ess_workbench.js
+++ b/www/js/ess_workbench.js
@@ -3062,10 +3062,10 @@ class ESSWorkbench {
             input.placeholder = 'value';
 
             // Pre-populate with first option from variants if available
+            // Options are {label, value} objects
             const opts = variantOptions[argName];
             if (opts && opts.length > 0) {
-                // Use the first option value as default
-                input.value = opts[0];
+                input.value = opts[0].value;
             }
 
             row.appendChild(input);
@@ -3082,10 +3082,11 @@ class ESSWorkbench {
                 emptyOpt.textContent = 'opts...';
                 optSelect.appendChild(emptyOpt);
 
-                opts.forEach(optVal => {
+                opts.forEach(opt => {
                     const o = document.createElement('option');
-                    o.value = optVal;
-                    o.textContent = optVal.length > 20 ? optVal.substring(0, 17) + '...' : optVal;
+                    o.value = opt.value;
+                    const display = opt.label !== opt.value ? opt.label : opt.value;
+                    o.textContent = display.length > 25 ? display.substring(0, 22) + '...' : display;
                     optSelect.appendChild(o);
                 });
 
@@ -3115,10 +3116,24 @@ class ESSWorkbench {
                         options[argName] = [];
                     }
                     // Parse the option values from the Tcl list
+                    // Options can be {label value} pairs or plain values
                     const optValues = TclParser.parseList(optStr);
                     optValues.forEach(v => {
-                        if (!options[argName].includes(v)) {
-                            options[argName].push(v);
+                        const parts = TclParser.parseList(v);
+                        let label, value;
+                        if (parts.length === 2) {
+                            // {label value} pair — display label, use value
+                            label = parts[0];
+                            value = parts[1];
+                        } else {
+                            // plain value — label and value are the same
+                            label = v;
+                            value = v;
+                        }
+                        // Store as {label, value} objects
+                        const existing = options[argName].find(o => o.value === value && o.label === label);
+                        if (!existing) {
+                            options[argName].push({ label, value });
                         }
                     });
                 }


### PR DESCRIPTION
## Summary

- Fixes `key "plank_restitution" not known in dictionary` error when running planko loader
- Variant `loader_options` use `{label value}` pairs — the args UI was passing the raw tuple instead of extracting the value

## Details

Variant options like:
```tcl
params { { defaults {} } { jittered { ball_jitter_x 8 ... } } }
```
are `{label value}` tuples where the label is for display and the value is what the loader needs. The backend's `variant_loader_defaults` extracts the value via `[lindex [lindex $options 0] 1]`.

Now `getVariantOptionsForLoader()` returns `{label, value}` objects, and the args UI:
- Pre-populates the input with `opts[0].value` (the actual value)
- Shows `opt.label` in the dropdown for user-friendly selection
- Sets `opt.value` on the input when a dropdown option is selected

## Test plan

- [ ] Run planko loader with default params — should succeed (empty params dict)
- [ ] Select "jittered" from params dropdown — input gets the dict, loader succeeds
- [ ] Circles loader still works (plain values like `1.5` are label=value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)