### PR TITLE
Add ess::get_variables for bulk variable fetch in loader sandbox

### DIFF
--- a/lib/ess-2.0.tm
+++ b/lib/ess-2.0.tm
@@ -530,6 +530,14 @@ oo::class create System {
         return [set [self namespace]::$var]
     }
 
+    method get_variables {} {
+        set result [dict create]
+        foreach var $_vars {
+            catch {dict set result $var [set [self namespace]::$var]}
+        }
+        return $result
+    }
+
     method set_variable { var val } {
         return [set [self namespace]::$var $val]
     }
@@ -1505,6 +1513,11 @@ namespace eval ess {
         return [set $current(state_system)::$name]
     }
 
+    proc get_variables {} {
+        variable current
+        return [$current(state_system) get_variables]
+    }
+
     proc evt_put {type subtype time args} {
         variable current
         if {[string is int $type]} {
@@ -1802,7 +1815,7 @@ namespace eval ess {
         name get_system set_version get_version set_protocol get_protocol
         set_variants get_variants set_variant get_variant add_variant
         reset_variant_args set_variant_args get_variant_args
-        get_variable set_variable set_parameters set_default_param_vals
+        get_variable get_variables set_variable set_parameters set_default_param_vals
         protocol_init protocol_deinit final_init
     }
     


### PR DESCRIPTION
## Summary
- Add `get_variables` method to `System` class and `ess` namespace that returns a dict of all system object variable name/value pairs
- Replace fragile `detectFreeVariables()` static analysis in loader sandbox with a single `send ess {ess::get_variables}` call
- Loader body now runs directly at global scope (no proc wrapper/upvar) with args set via `set` commands
- Remove dead `detectFreeVariables()` method (~40 lines)

## Test plan
- [ ] Load a system with variables (e.g., search/circles, planko/bounce)
- [ ] Open Loaders tab, select a loader, set args, click Run
- [ ] Verify system variables (screen_halfx, targ_radius, etc.) are available in sandbox
- [ ] Verify planko/bounce loaders work (previously failed on `$colors` array variable)
- [ ] Verify `ess::get_variables` returns correct dict from dserv console

🤖 Generated with [Claude Code](https://claude.com/claude-code)