### PR TITLE
Fix get_variables to handle unset system variables

### DIFF
--- a/lib/ess-2.0.tm
+++ b/lib/ess-2.0.tm
@@ -533,7 +533,9 @@ oo::class create System {
     method get_variables {} {
         set result [dict create]
         foreach var $_vars {
-            catch {dict set result $var [set [self namespace]::$var]}
+            if { ![catch {set [self namespace]::$var} val] } {
+                dict set result $var $val
+            }
         }
         return $result
     }


### PR DESCRIPTION
## Summary
- Fix `get_variables` method in `ess-2.0.tm` to properly catch errors from variables registered in `_vars` but not yet assigned a value
- Uses `catch {cmd} val` pattern with explicit result variable instead of wrapping the whole `dict set` in a catch block
- Fixes error: `can't read "::oo::Obj26::jump_targ_r": no such variable`

## Test plan
- [ ] From dserv terminal: `send ess {ess::get_variables}` — should return a dict of all set variables without errors
- [ ] Open Loaders tab, run a loader — variables should be fetched without errors in ESS process

🤖 Generated with [Claude Code](https://claude.com/claude-code)