### PR TITLE
Track screen params and system params in _vars for get_variables

### DIFF
--- a/lib/ess-2.0.tm
+++ b/lib/ess-2.0.tm
@@ -187,7 +187,7 @@ oo::class create System {
     method configure_stim { host } {
         variable current
         foreach var "screen_halfx screen_halfy screen_w screen_h" {
-            oo::objdefine [self] variable $var
+            my add_variable $var
         }
 
         ::ess::ess_info "Configuring stimulus host: $host" "stim"
@@ -489,9 +489,7 @@ oo::class create System {
         set t [dict get $::ess::param_types [string toupper $type]]
         dict set _params $pname [list $val $t $ptype]
         dict set _default_param_vals $pname $val
-        my variable $pname
-        oo::objdefine [self] variable $pname
-        set $pname $val
+        my add_variable $pname $val
     }
 
     method set_parameters {} {


### PR DESCRIPTION
## Summary
- `configure_stim` now uses `my add_variable` instead of raw `oo::objdefine` for `screen_halfx`, `screen_halfy`, `screen_w`, `screen_h`
- `add_param` now uses `my add_variable` instead of manual `my variable` + `oo::objdefine` + `set`
- Both changes ensure these variables are tracked in `_vars` and returned by `get_variables`
- Fixes: `can't read "screen_halfx": no such variable` in loader sandbox

## Test plan
- [ ] Reload system, then from dserv terminal: `send ess {ess::get_variables}` — should now include `screen_halfx`, `screen_halfy`, `screen_w`, `screen_h` and all params
- [ ] Run a loader from workbench that uses `$screen_halfx` — should work without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)