### PR TITLE
Use info exists instead of catch in get_variables

### DIFF
--- a/lib/ess-2.0.tm
+++ b/lib/ess-2.0.tm
@@ -530,9 +530,10 @@ oo::class create System {
 
     method get_variables {} {
         set result [dict create]
+        set ns [self namespace]
         foreach var $_vars {
-            if { ![catch {set [self namespace]::$var} val] } {
-                dict set result $var $val
+            if { [info exists ${ns}::$var] } {
+                dict set result $var [set ${ns}::$var]
             }
         }
         return $result


### PR DESCRIPTION
## Summary
- Replace `catch` with `info exists` check in `get_variables` to avoid triggering `::errorInfo` trace
- ESS has `trace add variable ::errorInfo write ::ess::error_callback` which fires even when errors are caught, producing spurious error messages like `can't read "::oo::Obj25::dist_r"`
- `info exists` cleanly skips unset variables without any error or trace side effects

## Test plan
- [ ] Reload system, run `send ess {ess::get_variables}` — should return cleanly with no error messages
- [ ] Run a loader from workbench — no spurious error messages in ESS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)