### PR TITLE
Add toggle-back behavior to loader lint error click

### DIFF
--- a/www/js/ess_workbench.js
+++ b/www/js/ess_workbench.js
@@ -3316,15 +3316,31 @@ class ESSWorkbench {
     jumpToLoaderLine(lineNum) {
         if (!this.loaderScriptEditor?.view) return;
 
-        const doc = this.loaderScriptEditor.view.state.doc;
-        const line = doc.line(Math.min(lineNum, doc.lines));
+        const view = this.loaderScriptEditor.view;
+        const doc = view.state.doc;
 
-        this.loaderScriptEditor.view.dispatch({
+        // Save current position before jumping
+        const currentLine = doc.lineAt(view.state.selection.main.anchor).number;
+
+        // If we're already at the target line, jump back to previous position
+        const targetLine = (currentLine === lineNum && this._loaderJumpBackLine)
+            ? this._loaderJumpBackLine
+            : lineNum;
+
+        // Store where we came from (only when jumping to the error)
+        if (targetLine === lineNum) {
+            this._loaderJumpBackLine = currentLine;
+        } else {
+            this._loaderJumpBackLine = null;
+        }
+
+        const line = doc.line(Math.min(targetLine, doc.lines));
+        view.dispatch({
             selection: { anchor: line.from },
             scrollIntoView: true
         });
 
-        this.loaderScriptEditor.view.focus();
+        view.focus();
     }
 
     async formatLoadersScript() {


### PR DESCRIPTION
## Summary
- Clicking the lint error status jumps to the error line
- Clicking again jumps back to where the cursor was before the first click
- Allows quick back-and-forth: see the unmatched brace, then return to where the fix is needed

## Test plan
- [ ] Remove a `}` near the top of a loaders file
- [ ] Click the error status — should jump to the unmatched brace (near bottom)
- [ ] Click again — should jump back to where you were editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)