### PR TITLE
Show friendly names for dict-type loader args

### DIFF
--- a/www/css/ess_workbench.css
+++ b/www/css/ess_workbench.css
@@ -2296,6 +2296,22 @@ body {
     border-color: var(--wb-accent);
 }
 
+.loader-arg-select {
+    flex: 1;
+    padding: 4px 8px;
+    background: var(--wb-bg-input);
+    border: 1px solid var(--wb-border);
+    border-radius: var(--wb-radius-sm);
+    color: var(--wb-text);
+    font-size: 0.8125rem;
+    cursor: pointer;
+}
+
+.loader-arg-select:focus {
+    outline: none;
+    border-color: var(--wb-accent);
+}
+
 .loader-arg-options {
     flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- When loader options have friendly labels (e.g., `params` with `{jittered {ball_jitter_x 10 ...}}`), show a select dropdown with the label names instead of a raw text input with the full dictionary value
- Matches how the variant editor displays these options
- Plain options (where label == value, like `nr { 4 20 60 }`) keep the existing text input + helper dropdown
- Updated `getLoaderArgValues` and `resetLoaderArgs` to handle both input types

## Test plan
- [ ] Open planko/bounce loaders — `params`/`board_params` should show "jittered" in a dropdown, not the raw dictionary
- [ ] `nplanks` with `{4 4} {8 8} {4+8 {4 8}}` should show "4", "8", "4+8" in dropdown
- [ ] `show_planks` should show "yes"/"no" in dropdown
- [ ] Plain options like `nr` should keep text input with helper dropdown
- [ ] Run a loader — values should be passed correctly to `ess::test_loader`

🤖 Generated with [Claude Code](https://claude.com/claude-code)