### PR TITLE
Always save and reload for loaders, show friendly arg names

### DIFF
--- a/www/ess_workbench.html
+++ b/www/ess_workbench.html
@@ -348,18 +348,11 @@
                                 Format
                             </button>
                             <div class="toolbar-divider"></div>
-                            <button class="btn btn-sm" id="loader-save-btn" disabled>
+                            <button class="btn btn-sm" id="loader-save-reload-btn" disabled>
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                     <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
                                     <polyline points="17 21 17 13 7 13 7 21"></polyline>
                                     <polyline points="7 3 7 8 15 8"></polyline>
-                                </svg>
-                                Save
-                            </button>
-                            <button class="btn btn-sm" id="loader-save-reload-btn" disabled>
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                    <polyline points="23 4 23 10 17 10"></polyline>
-                                    <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
                                 </svg>
                                 Save &amp; Reload
                             </button>


### PR DESCRIPTION
## Summary
- **Remove plain Save button** — only "Save & Reload" remains, since `ess::test_loader` requires the system to be reloaded to register new/modified loader methods
- **Select dropdowns for all args with variant options** — all args with variant options use a dropdown (showing friendly labels), args without options get a text input for manual entry
- Handles new loaders without variants gracefully (text input fallback)

## Test plan
- [ ] Only one save button visible ("Save & Reload")
- [ ] Save triggers both file save and `ess::reload_system`
- [ ] After saving a new loader, can immediately test it with Run
- [ ] Planko args show friendly labels in dropdowns
- [ ] A loader with no variant shows text inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)