### PR TITLE
Save always reloads, show friendly arg names, tidy toolbar

### DIFF
--- a/www/js/ess_workbench.js
+++ b/www/js/ess_workbench.js
@@ -2936,7 +2936,7 @@ class ESSWorkbench {
         this.parsedLoaderDefs.forEach(loader => {
             const opt = document.createElement('option');
             opt.value = loader.name;
-            opt.textContent = `${loader.name} (${loader.args.join(', ')})`;
+            opt.textContent = loader.name;
             select.appendChild(opt);
         });
 


### PR DESCRIPTION
## Summary
- **Save always reloads** — removed plain Save button; single "Save & Reload" ensures new/modified loaders are immediately testable via `ess::test_loader`
- **Loader dropdown shows name only** — args are already in the right panel, no need to repeat them in the dropdown taking up toolbar space
- **Select dropdowns for all args with variant options** — friendly labels like "jittered" instead of raw dictionaries; text input fallback for loaders without variants

## Test plan
- [ ] Only one save button visible ("Save & Reload"), toolbar not smooshed
- [ ] Loader dropdown shows just names (e.g., `setup_bounce` not `setup_bounce (nr, nplanks, ...)`)
- [ ] After saving a new loader, can immediately test it
- [ ] Args with variant options show select dropdowns with labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)