### PR TITLE
Fix commit button, datapoint leak, and snapshot performance

### DIFF
--- a/www/js/ess_registry_plugin.js
+++ b/www/js/ess_registry_plugin.js
@@ -57,7 +57,12 @@ const RegistryPlugin = {
 
     onSnapshot(wb, snapshot) {
         if (wb.registry && snapshot) {
-            this._checkSyncStatus(wb);
+            // Debounce sync status checks — avoid hammering the backend
+            // when multiple snapshots arrive in quick succession
+            clearTimeout(this._syncStatusTimer);
+            this._syncStatusTimer = setTimeout(() => {
+                this._checkSyncStatus(wb);
+            }, 500);
         }
     },
 
@@ -76,7 +81,7 @@ const RegistryPlugin = {
 
     onScriptSelect(wb, scriptName) {
         setTimeout(() => {
-            this._updateSingleSyncStatus(wb, 'scripts-sync-status', scriptName);
+            this._updateSyncStatusUI(wb);
         }, 50);
     },
 

--- a/www/js/ess_workbench.js
+++ b/www/js/ess_workbench.js
@@ -454,13 +454,26 @@ class ESSWorkbench {
             
             // Hide sidebar entries for scripts that don't exist
             this.updateScriptSidebarVisibility();
-            
-            // Update core displays
+
+            // Update config display (always visible/cheap)
             this.updateConfigDisplay();
-            this.updateVariantsEditor();
-            this.updateLoadersEditor();
-            this.updateScriptEditor();
-            this.updateStatesDiagram();
+
+            // Only update the active tab's content
+            this._snapshotDirty = true;
+            switch (this.currentTab) {
+                case 'variants':
+                    this.updateVariantsEditor();
+                    break;
+                case 'loaders':
+                    this.updateLoadersEditor();
+                    break;
+                case 'scripts':
+                    this.updateScriptEditor();
+                    break;
+                case 'states':
+                    this.updateStatesDiagram();
+                    break;
+            }
             
             // Update timestamp
             this.updateSnapshotTime(snapshot.timestamp);
@@ -923,16 +936,20 @@ class ESSWorkbench {
             content.classList.toggle('active', content.id === `tab-${tabName}`);
         });
         
-        // Initialize tab-specific content
-        if (tabName === 'scripts' && !this.editor) {
-            this.initEditor();
+        // Initialize tab-specific content and refresh if snapshot arrived while away
+        if (tabName === 'scripts') {
+            if (!this.editor) this.initEditor();
+            if (this._snapshotDirty) this.updateScriptEditor();
         } else if (tabName === 'states') {
             this.updateStatesDiagram();
         } else if (tabName === 'variants') {
             this.initVariantsTab();
+            if (this._snapshotDirty) this.updateVariantsEditor();
         } else if (tabName === 'loaders') {
             this.initLoadersTab();
+            if (this._snapshotDirty) this.updateLoadersEditor();
         }
+        this._snapshotDirty = false;
         
         // Notify plugins
         this._pluginHook('onTabSwitch', tabName);
@@ -1545,13 +1562,28 @@ class ESSWorkbench {
                 reject(new Error('WebSocket not connected'));
                 return;
             }
-            
+
             const responseId = `cmd_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-            
+            const dpName = `ess/cmd_response/${responseId}`;
+            let settled = false;
+
+            const cleanup = () => {
+                this.dpManager.unsubscribe(dpName, responseHandler);
+                // Remove the temporary datapoint from the server's table
+                if (this.connection?.ws?.readyState === WebSocket.OPEN) {
+                    this.connection.ws.send(JSON.stringify({
+                        cmd: 'eval',
+                        script: `dservClear ${dpName}`
+                    }));
+                }
+            };
+
             const responseHandler = (data) => {
-                if (data.name === `ess/cmd_response/${responseId}`) {
-                    this.dpManager.unsubscribe(`ess/cmd_response/${responseId}`, responseHandler);
-                    
+                if (data.name === dpName) {
+                    if (settled) return;
+                    settled = true;
+                    cleanup();
+
                     const value = data.data !== undefined ? data.data : data.value;
                     if (value && value.error) {
                         reject(new Error(value.error));
@@ -1560,24 +1592,26 @@ class ESSWorkbench {
                     }
                 }
             };
-            
-            this.dpManager.subscribe(`ess/cmd_response/${responseId}`, responseHandler);
-            
+
+            this.dpManager.subscribe(dpName, responseHandler);
+
             const wrappedCmd = `
                 if {[catch {${cmd}} result]} {
-                    dservSet ess/cmd_response/${responseId} [list error $result]
+                    dservSet ${dpName} [list error $result]
                 } else {
-                    dservSet ess/cmd_response/${responseId} $result
+                    dservSet ${dpName} $result
                 }
             `;
-            
+
             this.connection.ws.send(JSON.stringify({
                 cmd: 'eval',
                 script: wrappedCmd
             }));
-            
+
             setTimeout(() => {
-                this.dpManager.unsubscribe(`ess/cmd_response/${responseId}`, responseHandler);
+                if (settled) return;
+                settled = true;
+                cleanup();
                 reject(new Error('Command timeout'));
             }, 30000);
         });


### PR DESCRIPTION
## Summary
- Fix commit button staying disabled after committing one script and switching to another that also needs committing (`onScriptSelect` was only updating the status label, not the button state)
- Clean up temporary `ess/cmd_response/*` datapoints from the server's datapoint table after each `execTclCmd` call via `dservClear`, preventing unbounded memory growth during extended sessions
- Add `settled` flag to `execTclCmd` to prevent timeout and response handler from both firing
- Only update the active tab's editor content on snapshot arrival instead of all four tabs unconditionally; stale tabs refresh when switched to via `_snapshotDirty` flag
- Debounce `ess::sync_status` backend call (500ms) in the registry plugin to avoid redundant round-trips when snapshots arrive in quick succession

## Test plan
- [ ] Commit a script, switch to another modified script — verify commit button is active
- [ ] Leave workbench open for extended period — verify dserv memory stays stable
- [ ] Switch systems — verify it feels faster, and switching tabs still shows correct content
- [ ] Rapid snapshot changes — verify no duplicate sync status calls in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)