### PR TITLE
Fix datapoint leak, snapshot performance, and add native clear command

### DIFF
--- a/www/js/ess_workbench.js
+++ b/www/js/ess_workbench.js
@@ -1569,13 +1569,9 @@ class ESSWorkbench {
 
             const cleanup = () => {
                 this.dpManager.unsubscribe(dpName, responseHandler);
-                // Remove the temporary datapoint from the server's table
-                if (this.connection?.ws?.readyState === WebSocket.OPEN) {
-                    this.connection.ws.send(JSON.stringify({
-                        cmd: 'eval',
-                        script: `dservClear ${dpName}`
-                    }));
-                }
+                // Queue for batched cleanup instead of sending an eval
+                // per response (eval blocks the uWS event loop)
+                this._queueDatapointCleanup(dpName);
             };
 
             const responseHandler = (data) => {
@@ -1617,6 +1613,31 @@ class ESSWorkbench {
         });
     }
     
+    /**
+     * Queue a temporary datapoint name for batched cleanup.
+     * Uses the native WebSocket 'clear' command which runs directly
+     * on the dataserver without going through the Tcl interpreter,
+     * so it never blocks the uWS event loop.
+     */
+    _queueDatapointCleanup(dpName) {
+        if (!this._dpCleanupQueue) this._dpCleanupQueue = [];
+        this._dpCleanupQueue.push(dpName);
+
+        if (!this._dpCleanupTimer) {
+            this._dpCleanupTimer = setTimeout(() => {
+                this._dpCleanupTimer = null;
+                const names = this._dpCleanupQueue;
+                this._dpCleanupQueue = [];
+                if (names.length > 0 && this.connection?.ws?.readyState === WebSocket.OPEN) {
+                    this.connection.ws.send(JSON.stringify({
+                        cmd: 'clear',
+                        names: names
+                    }));
+                }
+            }, 2000);
+        }
+    }
+
     // Alias for backward compat (plugins used execRegistryCmd)
     async execRegistryCmd(cmd) {
         return this.execTclCmd(cmd);


### PR DESCRIPTION
## Summary
- **Datapoint leak fix**: Clean up temporary `ess/cmd_response/*` datapoints after each `execTclCmd` call, preventing unbounded growth of the datapoint table during extended sessions
- **Snapshot performance**: Only update the active tab's editor on snapshot arrival; deferred tabs refresh when switched to via `_snapshotDirty` flag
- **Debounce sync status**: Registry `ess::sync_status` backend call debounced (500ms) to avoid redundant round-trips on rapid snapshots
- **Commit button fix**: `onScriptSelect` now calls full `_updateSyncStatusUI` so the commit button state updates when switching scripts
- **Native WebSocket `clear` command**: Frontend uses the new `clear` WebSocket command (committed on main) for datapoint cleanup — bypasses Tcl interpreter entirely, no blocking

## Test plan
- [ ] Leave workbench open for extended period — verify dserv memory stays stable
- [ ] Promote an overlay script — verify no timeout
- [ ] Commit a script, switch to another modified script — verify commit button is active
- [ ] Switch systems — verify faster response, tabs still show correct content on switch
- [ ] Rapid snapshot changes — verify no duplicate sync status calls in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)