### PR TITLE
Add dservctl: Go CLI for dserv + dserv-agent

### DIFF
--- a/tools/dservctl/agent.go
+++ b/tools/dservctl/agent.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// AgentClient handles HTTP communication with the dserv-agent REST API.
+type AgentClient struct {
+	BaseURL    string
+	Token      string
+	HTTPClient *http.Client
+}
+
+// NewAgentClient creates an AgentClient from config.
+func NewAgentClient(cfg *Config) *AgentClient {
+	return &AgentClient{
+		BaseURL: cfg.AgentBaseURL(),
+		Token:   cfg.Token,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Do performs an HTTP request with auth and returns parsed JSON.
+func (c *AgentClient) Do(method, path string, body interface{}) (map[string]interface{}, error) {
+	url := c.BaseURL + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request to %s failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var result map[string]interface{}
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			// Try as array — some endpoints return arrays
+			var arr []interface{}
+			if err2 := json.Unmarshal(respBody, &arr); err2 == nil {
+				result = map[string]interface{}{"items": arr}
+			} else {
+				// Return raw text
+				result = map[string]interface{}{"raw": string(respBody)}
+			}
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		errMsg := fmt.Sprintf("HTTP %d", resp.StatusCode)
+		if result != nil {
+			if e, ok := result["error"].(string); ok {
+				errMsg = e
+			}
+		}
+		return result, fmt.Errorf("%s", errMsg)
+	}
+
+	return result, nil
+}
+
+// Get performs a GET request.
+func (c *AgentClient) Get(path string) (map[string]interface{}, error) {
+	return c.Do("GET", path, nil)
+}
+
+// Post performs a POST request with a JSON body.
+func (c *AgentClient) Post(path string, body interface{}) (map[string]interface{}, error) {
+	return c.Do("POST", path, body)
+}
+
+// GetRaw performs a GET request and returns the raw response bytes.
+// Useful for endpoints that return non-JSON (e.g., ZIP files).
+func (c *AgentClient) GetRaw(path string) ([]byte, string, error) {
+	url := c.BaseURL + path
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("create request: %w", err)
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("request to %s failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, resp.Header.Get("Content-Type"), nil
+}

--- a/tools/dservctl/cmd_agent.go
+++ b/tools/dservctl/cmd_agent.go
@@ -1,0 +1,441 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runStatus shows agent and dserv status.
+func runStatus(cfg *Config, args []string) int {
+	client := NewAgentClient(cfg)
+	result, err := client.Get("/api/status")
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	// Agent info
+	if agent, ok := result["agent"].(map[string]interface{}); ok {
+		fmt.Printf("Agent:    v%s (up %s)\n", strVal(agent, "version"), strVal(agent, "uptime"))
+	}
+
+	// Dserv info
+	if dserv, ok := result["dserv"].(map[string]interface{}); ok {
+		status := strVal(dserv, "status")
+		line := fmt.Sprintf("Dserv:    %s", status)
+		if v := strVal(dserv, "version"); v != "" {
+			line += fmt.Sprintf(" v%s", v)
+		}
+		if pid := intVal(dserv, "pid"); pid > 0 {
+			line += fmt.Sprintf(" (PID %d)", pid)
+		}
+		fmt.Println(line)
+	}
+
+	// System info
+	if sys, ok := result["system"].(map[string]interface{}); ok {
+		fmt.Printf("Host:     %s (%s/%s)\n", strVal(sys, "hostname"), strVal(sys, "os"), strVal(sys, "arch"))
+		if uptime := strVal(sys, "uptime"); uptime != "" {
+			fmt.Printf("Uptime:   %s\n", uptime)
+		}
+		if load := strVal(sys, "loadAvg"); load != "" {
+			fmt.Printf("Load:     %s\n", load)
+		}
+	}
+
+	// Extra services
+	if services, ok := result["services"].(map[string]interface{}); ok && len(services) > 0 {
+		fmt.Println("Services:")
+		for name, status := range services {
+			fmt.Printf("  %-20s %s\n", name, status)
+		}
+	}
+
+	return 0
+}
+
+// runMesh lists mesh nodes.
+func runMesh(cfg *Config, args []string) int {
+	client := NewAgentClient(cfg)
+
+	// Determine path — use workgroup filter if available
+	path := "/api/v1/mesh"
+	wg := cfg.Workgroup
+	if len(args) > 0 {
+		wg = args[0]
+	}
+	if wg != "" {
+		path += "?workgroup=" + wg
+	}
+
+	result, err := client.Get(path)
+	if err != nil {
+		// Fall back to /api/mesh/peers (client mode)
+		result, err = client.Get("/api/mesh/peers")
+		if err != nil {
+			PrintError("%v", err)
+			return 1
+		}
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	// Extract nodes
+	nodes := extractNodes(result)
+	if len(nodes) == 0 {
+		fmt.Println("No mesh nodes found.")
+		return 0
+	}
+
+	// Table output
+	headers := []string{"HOSTNAME", "IP", "PORT", "WORKGROUP", "STATUS", "STATE", "LAST SEEN"}
+	var rows [][]string
+	for _, node := range nodes {
+		rows = append(rows, []string{
+			strVal(node, "hostname"),
+			strVal(node, "ip"),
+			fmt.Sprintf("%d", intVal(node, "port")),
+			strVal(node, "workgroup"),
+			strVal(node, "status"),
+			strVal(node, "state"),
+			formatLastSeen(intVal(node, "lastSeenAgo")),
+		})
+	}
+
+	PrintTable(headers, rows)
+	return 0
+}
+
+// runService controls dserv or other systemd services.
+func runService(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl service <start|stop|restart|status> [service-name]\n")
+		return 2
+	}
+
+	action := args[0]
+	validActions := map[string]bool{"start": true, "stop": true, "restart": true, "status": true}
+	if !validActions[action] {
+		PrintError("unknown action %q (use start, stop, restart, or status)", action)
+		return 2
+	}
+
+	client := NewAgentClient(cfg)
+
+	var path string
+	if len(args) > 1 {
+		// Specific service
+		serviceName := args[1]
+		path = fmt.Sprintf("/api/service/%s/%s", serviceName, action)
+	} else {
+		// Default to dserv
+		path = fmt.Sprintf("/api/dserv/%s", action)
+	}
+
+	result, err := client.Post(path, nil)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	// Display result
+	if action == "status" {
+		status := strVal(result, "status")
+		fmt.Printf("Status: %s\n", status)
+		if v := strVal(result, "version"); v != "" {
+			fmt.Printf("Version: %s\n", v)
+		}
+		if pid := intVal(result, "pid"); pid > 0 {
+			fmt.Printf("PID: %d\n", pid)
+		}
+	} else {
+		if result["success"] == true {
+			fmt.Printf("Service %s: OK\n", action)
+		} else if errMsg := strVal(result, "error"); errMsg != "" {
+			PrintError("%s", errMsg)
+			return 1
+		}
+	}
+
+	return 0
+}
+
+// runComponents lists or installs components.
+func runComponents(cfg *Config, args []string) int {
+	client := NewAgentClient(cfg)
+
+	// Check for install subcommand
+	if len(args) > 0 && args[0] == "install" {
+		return runComponentInstall(cfg, client, args[1:])
+	}
+
+	result, err := client.Get("/api/components")
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	// Components come back as an array
+	items, ok := result["items"].([]interface{})
+	if !ok || len(items) == 0 {
+		fmt.Println("No components found.")
+		return 0
+	}
+
+	headers := []string{"ID", "NAME", "INSTALLED", "CURRENT", "LATEST", "UPDATE"}
+	var rows [][]string
+	for _, item := range items {
+		cs, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		comp, _ := cs["component"].(map[string]interface{})
+		installed := "no"
+		if cs["installed"] == true {
+			installed = "yes"
+		}
+		update := ""
+		if cs["updateAvailable"] == true {
+			update = "available"
+		}
+		rows = append(rows, []string{
+			strVal(comp, "id"),
+			strVal(comp, "name"),
+			installed,
+			strVal(cs, "currentVersion"),
+			strVal(cs, "latestVersion"),
+			update,
+		})
+	}
+
+	PrintTable(headers, rows)
+	return 0
+}
+
+func runComponentInstall(cfg *Config, client *AgentClient, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl components install <component-id> [--asset ASSET]\n")
+		return 2
+	}
+
+	componentID := args[0]
+
+	// Parse optional --asset flag
+	var asset string
+	for i := 1; i < len(args); i++ {
+		if args[i] == "--asset" && i+1 < len(args) {
+			asset = args[i+1]
+			i++
+		}
+	}
+
+	path := fmt.Sprintf("/api/components/%s/install", componentID)
+	if asset != "" {
+		path += "?asset=" + asset
+	}
+
+	result, err := client.Post(path, nil)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	fmt.Printf("Installation started for %s\n", componentID)
+	if status := strVal(result, "status"); status != "" {
+		fmt.Printf("Status: %s\n", status)
+	}
+	return 0
+}
+
+// runLogs shows service logs.
+func runLogs(cfg *Config, args []string) int {
+	service := ""
+	lines := "50"
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--service", "-s":
+			if i+1 < len(args) {
+				service = args[i+1]
+				i++
+			}
+		case "--lines", "-n":
+			if i+1 < len(args) {
+				lines = args[i+1]
+				i++
+			}
+		default:
+			// First bare arg is service name
+			if service == "" {
+				service = args[i]
+			}
+		}
+	}
+
+	client := NewAgentClient(cfg)
+	path := fmt.Sprintf("/api/logs?lines=%s", lines)
+	if service != "" {
+		path += "&service=" + service
+	}
+
+	result, err := client.Get(path)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	// Print raw logs
+	if logs, ok := result["logs"].(string); ok {
+		fmt.Print(logs)
+	}
+	return 0
+}
+
+// --- Helpers ---
+
+func printJSON(data interface{}) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(data)
+}
+
+func strVal(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+		return fmt.Sprintf("%v", v)
+	}
+	return ""
+}
+
+func intVal(m map[string]interface{}, key string) int {
+	if v, ok := m[key]; ok {
+		switch n := v.(type) {
+		case float64:
+			return int(n)
+		case int:
+			return n
+		case json.Number:
+			if i, err := n.Int64(); err == nil {
+				return int(i)
+			}
+		}
+	}
+	return 0
+}
+
+func extractNodes(result map[string]interface{}) []map[string]interface{} {
+	// Try "nodes" key (MeshResponse format)
+	if nodes, ok := result["nodes"].([]interface{}); ok {
+		return toMapSlice(nodes)
+	}
+	// Try "items" key (array wrapper)
+	if items, ok := result["items"].([]interface{}); ok {
+		return toMapSlice(items)
+	}
+	return nil
+}
+
+func toMapSlice(items []interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
+	for _, item := range items {
+		if m, ok := item.(map[string]interface{}); ok {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+func formatLastSeen(secondsAgo int) string {
+	if secondsAgo <= 0 {
+		return "now"
+	}
+	if secondsAgo < 60 {
+		return fmt.Sprintf("%ds ago", secondsAgo)
+	}
+	if secondsAgo < 3600 {
+		return fmt.Sprintf("%dm ago", secondsAgo/60)
+	}
+	return fmt.Sprintf("%dh ago", secondsAgo/3600)
+}
+
+// requireWorkgroup ensures a workgroup is configured, printing an error if not.
+func requireWorkgroup(cfg *Config) bool {
+	if cfg.Workgroup == "" {
+		PrintError("workgroup required (use --workgroup or set DSERV_WORKGROUP)")
+		return false
+	}
+	return true
+}
+
+// requireUser ensures a user is configured.
+func requireUser(cfg *Config) bool {
+	if cfg.User == "" {
+		// Try to get from environment
+		cfg.User = os.Getenv("USER")
+		if cfg.User == "" {
+			PrintError("user required (use --user or set DSERV_USER)")
+			return false
+		}
+	}
+	return true
+}
+
+// parseServiceFlag extracts a -s service flag from args, returning the service name and remaining args.
+func parseServiceFlag(args []string) (string, []string) {
+	var service string
+	var remaining []string
+	for i := 0; i < len(args); i++ {
+		if (args[i] == "-s" || args[i] == "--service") && i+1 < len(args) {
+			service = args[i+1]
+			i++
+		} else {
+			remaining = append(remaining, args[i])
+		}
+	}
+	return service, remaining
+}
+
+// joinPath builds a URL path from segments, ensuring proper encoding.
+func joinPath(parts ...string) string {
+	var cleaned []string
+	for _, p := range parts {
+		p = strings.TrimPrefix(p, "/")
+		p = strings.TrimSuffix(p, "/")
+		if p != "" {
+			cleaned = append(cleaned, p)
+		}
+	}
+	return "/" + strings.Join(cleaned, "/")
+}

--- a/tools/dservctl/cmd_interp.go
+++ b/tools/dservctl/cmd_interp.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runDirectCommand sends a single command directly to the dserv main interpreter.
+func runDirectCommand(cfg *Config, cmd string) int {
+	resp, err := SendToDserv(cfg.Host, cmd)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+	if PrintResponse(resp, false) {
+		return 1
+	}
+	return 0
+}
+
+// runInterpCommand sends a single command to an interpreter (or dserv if interp is empty).
+func runInterpCommand(cfg *Config, interp string, cmd string) int {
+	resp, err := Send(cfg.Host, interp, cmd)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+	if PrintResponse(resp, false) {
+		return 1
+	}
+	return 0
+}
+
+// runStdinCommands reads commands from stdin and sends them to an interpreter.
+func runStdinCommands(cfg *Config, interp string) int {
+	scanner := bufio.NewScanner(os.Stdin)
+	anyErrors := false
+	processed := 0
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		resp, err := Send(cfg.Host, interp, line)
+		if err != nil {
+			PrintError("%v", err)
+			anyErrors = true
+			continue
+		}
+		if PrintResponse(resp, false) {
+			anyErrors = true
+		}
+		processed++
+	}
+
+	if err := scanner.Err(); err != nil {
+		PrintError("reading stdin: %v", err)
+		return 1
+	}
+
+	if processed == 0 {
+		return 1
+	}
+	if anyErrors {
+		return 1
+	}
+	return 0
+}
+
+// runStim handles the stim command — direct connection to STIM port.
+func runStim(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		if isStdinPiped() {
+			return runStdinCommands(cfg, "stim")
+		}
+		// Interactive shell targeting stim
+		return runShell(cfg, []string{"-s", "stim"})
+	}
+
+	cmd := strings.Join(args, " ")
+
+	// Handle -c flag for stim
+	if args[0] == "-c" {
+		if len(args) < 2 {
+			fmt.Fprintf(os.Stderr, "Error: -c requires a command\n")
+			return 2
+		}
+		cmd = strings.Join(args[1:], " ")
+	}
+
+	resp, err := SendToSTIM(cfg.Host, cmd)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+	if PrintResponse(resp, false) {
+		return 1
+	}
+	return 0
+}

--- a/tools/dservctl/cmd_registry.go
+++ b/tools/dservctl/cmd_registry.go
@@ -1,0 +1,531 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// runSystems lists ESS systems in a workgroup.
+func runSystems(cfg *Config, args []string) int {
+	wg := cfg.Workgroup
+	if len(args) > 0 {
+		wg = args[0]
+	}
+	if wg == "" {
+		PrintError("workgroup required (use --workgroup or provide as argument)")
+		return 2
+	}
+
+	client := NewAgentClient(cfg)
+	systems, err := client.ListSystems(wg)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(systems)
+		return 0
+	}
+
+	if len(systems) == 0 {
+		fmt.Printf("No systems found in workgroup %q.\n", wg)
+		return 0
+	}
+
+	headers := []string{"NAME", "VERSION", "PROTOCOLS", "SCRIPTS", "UPDATED BY", "UPDATED"}
+	var rows [][]string
+	for _, sys := range systems {
+		protos := ""
+		if p, ok := sys["protocols"].([]interface{}); ok {
+			names := make([]string, len(p))
+			for i, v := range p {
+				names[i] = fmt.Sprintf("%v", v)
+			}
+			protos = strings.Join(names, ", ")
+		}
+		rows = append(rows, []string{
+			strVal(sys, "name"),
+			strVal(sys, "version"),
+			protos,
+			fmt.Sprintf("%d", intVal(sys, "scriptCount")),
+			strVal(sys, "updatedBy"),
+			formatTime(strVal(sys, "updatedAt")),
+		})
+	}
+
+	PrintTable(headers, rows)
+	return 0
+}
+
+// runScripts lists scripts for a system grouped by protocol.
+func runScripts(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl scripts <system> [--version V]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system := args[0]
+	version := ""
+	for i := 1; i < len(args); i++ {
+		if args[i] == "--version" && i+1 < len(args) {
+			version = args[i+1]
+			i++
+		}
+	}
+
+	client := NewAgentClient(cfg)
+	result, err := client.GetScripts(cfg.Workgroup, system, version)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	// Scripts are grouped by protocol key
+	headers := []string{"PROTOCOL", "TYPE", "FILENAME", "CHECKSUM", "UPDATED BY"}
+	var rows [][]string
+	for key, val := range result {
+		if key == "system" || key == "version" || key == "workgroup" {
+			continue
+		}
+		scripts, ok := val.([]interface{})
+		if !ok {
+			continue
+		}
+		proto := key
+		if proto == "_system" {
+			proto = "(system)"
+		}
+		for _, s := range scripts {
+			script, ok := s.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			checksum := strVal(script, "checksum")
+			if len(checksum) > 8 {
+				checksum = checksum[:8]
+			}
+			rows = append(rows, []string{
+				proto,
+				strVal(script, "type"),
+				strVal(script, "filename"),
+				checksum,
+				strVal(script, "updatedBy"),
+			})
+		}
+	}
+
+	if len(rows) == 0 {
+		fmt.Printf("No scripts found for system %q.\n", system)
+		return 0
+	}
+
+	PrintTable(headers, rows)
+	return 0
+}
+
+// runScript handles get/save/delete for a single script.
+func runScript(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "  dservctl script get <system> <protocol> <type> [--version V] [--output FILE]\n")
+		fmt.Fprintf(os.Stderr, "  dservctl script save <system> <protocol> <type> [--file FILE] [--comment MSG] [--version V]\n")
+		fmt.Fprintf(os.Stderr, "  dservctl script delete <system> <protocol> <type>\n")
+		return 2
+	}
+
+	switch args[0] {
+	case "get":
+		return runScriptGet(cfg, args[1:])
+	case "save":
+		return runScriptSave(cfg, args[1:])
+	case "delete":
+		return runScriptDelete(cfg, args[1:])
+	default:
+		PrintError("unknown script subcommand %q (use get, save, or delete)", args[0])
+		return 2
+	}
+}
+
+func runScriptGet(cfg *Config, args []string) int {
+	if len(args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl script get <system> <protocol> <type> [--version V] [--output FILE]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system, protocol, scriptType := args[0], args[1], args[2]
+	version := ""
+	output := ""
+	for i := 3; i < len(args); i++ {
+		switch args[i] {
+		case "--version":
+			if i+1 < len(args) {
+				version = args[i+1]
+				i++
+			}
+		case "--output", "-o":
+			if i+1 < len(args) {
+				output = args[i+1]
+				i++
+			}
+		}
+	}
+
+	client := NewAgentClient(cfg)
+	result, err := client.GetScript(cfg.Workgroup, system, protocol, scriptType, version)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	content := strVal(result, "content")
+
+	if output != "" {
+		if err := os.WriteFile(output, []byte(content), 0644); err != nil {
+			PrintError("writing file: %v", err)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "Written to %s\n", output)
+	} else {
+		fmt.Print(content)
+	}
+
+	return 0
+}
+
+func runScriptSave(cfg *Config, args []string) int {
+	if len(args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl script save <system> <protocol> <type> [--file FILE] [--comment MSG] [--version V]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+	if !requireUser(cfg) {
+		return 2
+	}
+
+	system, protocol, scriptType := args[0], args[1], args[2]
+	version := ""
+	file := ""
+	comment := ""
+	for i := 3; i < len(args); i++ {
+		switch args[i] {
+		case "--version":
+			if i+1 < len(args) {
+				version = args[i+1]
+				i++
+			}
+		case "--file", "-f":
+			if i+1 < len(args) {
+				file = args[i+1]
+				i++
+			}
+		case "--comment", "-m":
+			if i+1 < len(args) {
+				comment = args[i+1]
+				i++
+			}
+		}
+	}
+
+	// Read content from file or stdin
+	var content []byte
+	var err error
+	if file != "" {
+		content, err = os.ReadFile(file)
+		if err != nil {
+			PrintError("reading file: %v", err)
+			return 1
+		}
+	} else {
+		content, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			PrintError("reading stdin: %v", err)
+			return 1
+		}
+	}
+
+	if len(content) == 0 {
+		PrintError("no content to save (provide --file or pipe content to stdin)")
+		return 2
+	}
+
+	client := NewAgentClient(cfg)
+
+	// Get current checksum for conflict detection
+	expectedChecksum := ""
+	existing, err := client.GetScript(cfg.Workgroup, system, protocol, scriptType, version)
+	if err == nil && existing != nil {
+		expectedChecksum = strVal(existing, "checksum")
+	}
+
+	// Save
+	req := map[string]interface{}{
+		"content":          string(content),
+		"expectedChecksum": expectedChecksum,
+		"updatedBy":        cfg.User,
+		"comment":          comment,
+	}
+
+	result, err := client.SaveScript(cfg.Workgroup, system, protocol, scriptType, version, req)
+	if err != nil {
+		if strings.Contains(err.Error(), "conflict") {
+			PrintError("conflict: script was modified by someone else. Fetch the latest version and retry.")
+		} else {
+			PrintError("%v", err)
+		}
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	checksum := ""
+	if result != nil {
+		checksum = strVal(result, "checksum")
+		if len(checksum) > 8 {
+			checksum = checksum[:8]
+		}
+	}
+	fmt.Printf("Saved %s/%s/%s (checksum: %s)\n", system, protocol, scriptType, checksum)
+	return 0
+}
+
+func runScriptDelete(cfg *Config, args []string) int {
+	if len(args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl script delete <system> <protocol> <type>\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system, protocol, scriptType := args[0], args[1], args[2]
+
+	client := NewAgentClient(cfg)
+	_, err := client.DeleteScript(cfg.Workgroup, system, protocol, scriptType)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	fmt.Printf("Deleted %s/%s/%s\n", system, protocol, scriptType)
+	return 0
+}
+
+// runHistory shows version history for a script.
+func runHistory(cfg *Config, args []string) int {
+	if len(args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl history <system> <protocol> <type>\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system, protocol, scriptType := args[0], args[1], args[2]
+
+	client := NewAgentClient(cfg)
+	result, err := client.GetHistory(cfg.Workgroup, system, protocol, scriptType)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	history := extractList(result, "history")
+	if len(history) == 0 {
+		fmt.Println("No history found.")
+		return 0
+	}
+
+	headers := []string{"#", "CHECKSUM", "SAVED BY", "SAVED AT", "COMMENT"}
+	var rows [][]string
+	for i, entry := range history {
+		checksum := strVal(entry, "checksum")
+		if len(checksum) > 8 {
+			checksum = checksum[:8]
+		}
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", i+1),
+			checksum,
+			strVal(entry, "savedBy"),
+			formatTime(strVal(entry, "savedAt")),
+			strVal(entry, "comment"),
+		})
+	}
+
+	PrintTable(headers, rows)
+	return 0
+}
+
+// runTemplates lists or adds templates.
+func runTemplates(cfg *Config, args []string) int {
+	if len(args) > 0 && args[0] == "add" {
+		return runTemplateAdd(cfg, args[1:])
+	}
+
+	client := NewAgentClient(cfg)
+	templates, err := client.ListTemplates()
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(templates)
+		return 0
+	}
+
+	if len(templates) == 0 {
+		fmt.Println("No templates available.")
+		return 0
+	}
+
+	headers := []string{"NAME", "VERSION", "DESCRIPTION", "PROTOCOLS", "SCRIPTS"}
+	var rows [][]string
+	for _, tmpl := range templates {
+		protos := ""
+		if p, ok := tmpl["protocols"].([]interface{}); ok {
+			names := make([]string, len(p))
+			for i, v := range p {
+				names[i] = fmt.Sprintf("%v", v)
+			}
+			protos = strings.Join(names, ", ")
+		}
+		rows = append(rows, []string{
+			strVal(tmpl, "name"),
+			strVal(tmpl, "version"),
+			strVal(tmpl, "description"),
+			protos,
+			fmt.Sprintf("%d", intVal(tmpl, "scriptCount")),
+		})
+	}
+
+	PrintTable(headers, rows)
+	return 0
+}
+
+func runTemplateAdd(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl templates add <template-name> [--workgroup WG]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+	if !requireUser(cfg) {
+		return 2
+	}
+
+	templateName := args[0]
+
+	client := NewAgentClient(cfg)
+	result, err := client.AddToWorkgroup(templateName, cfg.Workgroup, cfg.User)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	fmt.Printf("Added template %q to workgroup %q\n", templateName, cfg.Workgroup)
+	return 0
+}
+
+// runExport exports a workgroup or system as ZIP.
+func runExport(cfg *Config, args []string) int {
+	wg := cfg.Workgroup
+	system := ""
+	output := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-o", "--output":
+			if i+1 < len(args) {
+				output = args[i+1]
+				i++
+			}
+		default:
+			if wg == "" {
+				wg = args[i]
+			} else if system == "" {
+				system = args[i]
+			}
+		}
+	}
+
+	if wg == "" {
+		PrintError("workgroup required")
+		return 2
+	}
+
+	if output == "" {
+		if system != "" {
+			output = system + ".zip"
+		} else {
+			output = wg + ".zip"
+		}
+	}
+
+	client := NewAgentClient(cfg)
+	data, err := client.ExportZip(wg, system)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if err := os.WriteFile(output, data, 0644); err != nil {
+		PrintError("writing file: %v", err)
+		return 1
+	}
+
+	fmt.Printf("Exported to %s (%d bytes)\n", output, len(data))
+	return 0
+}
+
+// --- helpers ---
+
+func formatTime(s string) string {
+	if s == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		// Try other formats
+		t, err = time.Parse(time.RFC3339, s)
+		if err != nil {
+			return s
+		}
+	}
+	return t.Local().Format("2006-01-02 15:04")
+}

--- a/tools/dservctl/cmd_sandbox.go
+++ b/tools/dservctl/cmd_sandbox.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// runSandbox dispatches sandbox subcommands.
+func runSandbox(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "  dservctl sandbox create <system> <version> [--from VERSION] [--comment MSG]\n")
+		fmt.Fprintf(os.Stderr, "  dservctl sandbox promote <system> [--from VERSION] [--to VERSION] [--comment MSG]\n")
+		fmt.Fprintf(os.Stderr, "  dservctl sandbox sync <system> <version> [--from VERSION]\n")
+		fmt.Fprintf(os.Stderr, "  dservctl sandbox delete <system> <version>\n")
+		fmt.Fprintf(os.Stderr, "  dservctl sandbox versions <system>\n")
+		return 2
+	}
+
+	switch args[0] {
+	case "create":
+		return runSandboxCreate(cfg, args[1:])
+	case "promote":
+		return runSandboxPromote(cfg, args[1:])
+	case "sync":
+		return runSandboxSync(cfg, args[1:])
+	case "delete":
+		return runSandboxDelete(cfg, args[1:])
+	case "versions":
+		return runSandboxVersions(cfg, args[1:])
+	default:
+		PrintError("unknown sandbox subcommand %q (use create, promote, sync, delete, or versions)", args[0])
+		return 2
+	}
+}
+
+func runSandboxCreate(cfg *Config, args []string) int {
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl sandbox create <system> <version> [--from VERSION] [--comment MSG]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+	if !requireUser(cfg) {
+		return 2
+	}
+
+	system := args[0]
+	toVersion := args[1]
+	fromVersion := "main"
+	comment := ""
+
+	for i := 2; i < len(args); i++ {
+		switch args[i] {
+		case "--from":
+			if i+1 < len(args) {
+				fromVersion = args[i+1]
+				i++
+			}
+		case "--comment", "-m":
+			if i+1 < len(args) {
+				comment = args[i+1]
+				i++
+			}
+		}
+	}
+
+	client := NewAgentClient(cfg)
+	result, err := client.CreateSandbox(cfg.Workgroup, system, fromVersion, toVersion, cfg.User, comment)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	fmt.Printf("Created sandbox %q from %q for system %q (%d scripts copied)\n",
+		toVersion, fromVersion, system, intVal(result, "scriptCount"))
+	return 0
+}
+
+func runSandboxPromote(cfg *Config, args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl sandbox promote <system> [--from VERSION] [--to VERSION] [--comment MSG]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+	if !requireUser(cfg) {
+		return 2
+	}
+
+	system := args[0]
+	fromVersion := ""
+	toVersion := "main"
+	comment := ""
+
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--from":
+			if i+1 < len(args) {
+				fromVersion = args[i+1]
+				i++
+			}
+		case "--to":
+			if i+1 < len(args) {
+				toVersion = args[i+1]
+				i++
+			}
+		case "--comment", "-m":
+			if i+1 < len(args) {
+				comment = args[i+1]
+				i++
+			}
+		}
+	}
+
+	if fromVersion == "" {
+		PrintError("--from VERSION is required (the sandbox version to promote)")
+		return 2
+	}
+
+	client := NewAgentClient(cfg)
+	result, err := client.PromoteSandbox(cfg.Workgroup, system, fromVersion, toVersion, cfg.User, comment)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	fmt.Printf("Promoted %q → %q for system %q (%d scripts)\n",
+		fromVersion, toVersion, system, intVal(result, "scriptCount"))
+	return 0
+}
+
+func runSandboxSync(cfg *Config, args []string) int {
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl sandbox sync <system> <version> [--from VERSION]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+	if !requireUser(cfg) {
+		return 2
+	}
+
+	system := args[0]
+	toVersion := args[1]
+	fromVersion := "main"
+
+	for i := 2; i < len(args); i++ {
+		if args[i] == "--from" && i+1 < len(args) {
+			fromVersion = args[i+1]
+			i++
+		}
+	}
+
+	client := NewAgentClient(cfg)
+	result, err := client.SyncSandbox(cfg.Workgroup, system, fromVersion, toVersion, cfg.User)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	fmt.Printf("Synced %q → %q for system %q (%d scripts)\n",
+		fromVersion, toVersion, system, intVal(result, "scriptCount"))
+	return 0
+}
+
+func runSandboxDelete(cfg *Config, args []string) int {
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl sandbox delete <system> <version>\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system := args[0]
+	version := args[1]
+
+	if version == "main" {
+		PrintError("cannot delete main version")
+		return 1
+	}
+
+	client := NewAgentClient(cfg)
+	_, err := client.DeleteSandbox(cfg.Workgroup, system, version)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(map[string]interface{}{"deleted": true, "version": version})
+		return 0
+	}
+
+	fmt.Printf("Deleted sandbox %q for system %q\n", version, system)
+	return 0
+}
+
+func runSandboxVersions(cfg *Config, args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl sandbox versions <system>\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system := args[0]
+
+	client := NewAgentClient(cfg)
+	result, err := client.ListVersions(cfg.Workgroup, system)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	versions := extractList(result, "versions")
+	if len(versions) == 0 {
+		fmt.Printf("No versions found for system %q.\n", system)
+		return 0
+	}
+
+	headers := []string{"VERSION", "SCRIPTS", "UPDATED BY", "UPDATED", "DESCRIPTION"}
+	var rows [][]string
+	for _, v := range versions {
+		ver := strVal(v, "version")
+		label := ver
+		if ver == "main" {
+			label = "main *"
+		}
+		rows = append(rows, []string{
+			label,
+			fmt.Sprintf("%d", intVal(v, "scriptCount")),
+			strVal(v, "updatedBy"),
+			formatTime(strVal(v, "updatedAt")),
+			strVal(v, "description"),
+		})
+	}
+
+	PrintTable(headers, rows)
+	return 0
+}

--- a/tools/dservctl/cmd_sync.go
+++ b/tools/dservctl/cmd_sync.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// runSync syncs scripts from the registry to a local directory.
+// Uses manifest-based diffing: computes local checksums, sends to server,
+// server returns only changed scripts.
+func runSync(cfg *Config, args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl sync <system> [--dir DIR] [--version V] [--dry-run]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system := args[0]
+	dir := "."
+	version := ""
+	dryRun := false
+
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--dir", "-d":
+			if i+1 < len(args) {
+				dir = args[i+1]
+				i++
+			}
+		case "--version":
+			if i+1 < len(args) {
+				version = args[i+1]
+				i++
+			}
+		case "--dry-run", "-n":
+			dryRun = true
+		}
+	}
+
+	// Ensure directory exists
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		PrintError("creating directory: %v", err)
+		return 1
+	}
+
+	// Step 1: Get manifest from server
+	client := NewAgentClient(cfg)
+	manifest, err := client.GetManifest(cfg.Workgroup, system, version)
+	if err != nil {
+		PrintError("fetching manifest: %v", err)
+		return 1
+	}
+
+	if manifest == nil {
+		PrintError("system %q not found", system)
+		return 1
+	}
+
+	scripts := extractList(manifest, "scripts")
+	if len(scripts) == 0 {
+		fmt.Println("No scripts in manifest.")
+		return 0
+	}
+
+	// Step 2: Compute local checksums for comparison
+	localChecksums := make(map[string]string)
+	for _, s := range scripts {
+		protocol := strVal(s, "protocol")
+		scriptType := strVal(s, "type")
+		filename := strVal(s, "filename")
+
+		if filename == "" {
+			filename = scriptType
+		}
+
+		// Determine local path: protocol/filename (or just filename for _system)
+		localPath := localFilePath(dir, protocol, filename)
+		data, err := os.ReadFile(localPath)
+		if err == nil {
+			hash := sha256.Sum256(data)
+			localChecksums[protocol+"/"+scriptType] = fmt.Sprintf("%x", hash)
+		}
+	}
+
+	// Step 3: Send checksums to server for diff
+	syncResult, err := client.SyncCheck(cfg.Workgroup, system, localChecksums, version)
+	if err != nil {
+		PrintError("sync check: %v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(syncResult)
+		return 0
+	}
+
+	// Step 4: Process stale scripts (need updating)
+	stale := extractStaleScripts(syncResult)
+	extra := extractStringList(syncResult, "extra")
+	unchanged := intVal(syncResult, "unchanged")
+
+	if len(stale) == 0 && len(extra) == 0 {
+		fmt.Printf("All %d scripts up to date.\n", unchanged)
+		return 0
+	}
+
+	if dryRun {
+		if len(stale) > 0 {
+			fmt.Printf("Would download %d script(s):\n", len(stale))
+			for _, s := range stale {
+				fmt.Printf("  %s/%s → %s\n",
+					strVal(s, "protocol"), strVal(s, "type"),
+					localFilePath(dir, strVal(s, "protocol"), fileOrType(s)))
+			}
+		}
+		if len(extra) > 0 {
+			fmt.Printf("Local files not in registry (%d):\n", len(extra))
+			for _, key := range extra {
+				fmt.Printf("  %s\n", key)
+			}
+		}
+		return 0
+	}
+
+	// Step 5: Write updated scripts to disk
+	downloaded := 0
+	for _, s := range stale {
+		protocol := strVal(s, "protocol")
+		filename := fileOrType(s)
+		content := strVal(s, "content")
+
+		localPath := localFilePath(dir, protocol, filename)
+
+		// Ensure subdirectory exists
+		if subdir := filepath.Dir(localPath); subdir != "." {
+			if err := os.MkdirAll(subdir, 0755); err != nil {
+				PrintError("creating directory %s: %v", subdir, err)
+				continue
+			}
+		}
+
+		if err := os.WriteFile(localPath, []byte(content), 0644); err != nil {
+			PrintError("writing %s: %v", localPath, err)
+			continue
+		}
+		downloaded++
+		if cfg.Verbose {
+			fmt.Printf("  ↓ %s\n", localPath)
+		}
+	}
+
+	fmt.Printf("Synced %d updated, %d unchanged", downloaded, unchanged)
+	if len(extra) > 0 {
+		fmt.Printf(", %d local-only", len(extra))
+	}
+	fmt.Println()
+
+	if len(extra) > 0 && cfg.Verbose {
+		fmt.Println("Local files not in registry:")
+		for _, key := range extra {
+			fmt.Printf("  %s\n", key)
+		}
+	}
+
+	return 0
+}
+
+// localFilePath returns the local file path for a script.
+// Scripts in "_system" or "_" protocol go directly in the dir.
+// Others go in a protocol subdirectory.
+func localFilePath(dir, protocol, filename string) string {
+	if protocol == "" || protocol == "_" || protocol == "_system" {
+		return filepath.Join(dir, filename)
+	}
+	return filepath.Join(dir, protocol, filename)
+}
+
+// fileOrType returns filename if set, otherwise falls back to type.
+func fileOrType(s map[string]interface{}) string {
+	fn := strVal(s, "filename")
+	if fn != "" {
+		return fn
+	}
+	return strVal(s, "type")
+}
+
+// extractStaleScripts extracts the "stale" array from a sync response.
+func extractStaleScripts(result map[string]interface{}) []map[string]interface{} {
+	if items, ok := result["stale"].([]interface{}); ok {
+		return toMapSlice(items)
+	}
+	return nil
+}
+
+// extractStringList extracts a string array from a result map.
+func extractStringList(result map[string]interface{}, key string) []string {
+	items, ok := result[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, v := range items {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// computeLocalChecksums walks a directory and builds protocol/type → checksum map.
+// This is an alternative approach that doesn't require the manifest first.
+func computeLocalChecksums(dir string) (map[string]string, error) {
+	checksums := make(map[string]string)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return checksums, nil // empty dir is fine
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Protocol subdirectory
+			protocol := entry.Name()
+			subEntries, err := os.ReadDir(filepath.Join(dir, protocol))
+			if err != nil {
+				continue
+			}
+			for _, sub := range subEntries {
+				if sub.IsDir() {
+					continue
+				}
+				data, err := os.ReadFile(filepath.Join(dir, protocol, sub.Name()))
+				if err != nil {
+					continue
+				}
+				hash := sha256.Sum256(data)
+				key := protocol + "/" + stripExtension(sub.Name())
+				checksums[key] = fmt.Sprintf("%x", hash)
+			}
+		} else {
+			// System-level file
+			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			hash := sha256.Sum256(data)
+			key := "_system/" + stripExtension(entry.Name())
+			checksums[key] = fmt.Sprintf("%x", hash)
+		}
+	}
+
+	return checksums, nil
+}
+
+func stripExtension(name string) string {
+	if idx := strings.LastIndex(name, "."); idx > 0 {
+		return name[:idx]
+	}
+	return name
+}

--- a/tools/dservctl/config.go
+++ b/tools/dservctl/config.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Config holds all configuration for dservctl
+type Config struct {
+	Host      string // Target host
+	AgentPort int    // Agent HTTP port
+	Token     string // Bearer token for agent API
+	Workgroup string // Default workgroup
+	User      string // Username for registry operations
+	JSON      bool   // JSON output mode
+	Verbose   bool   // Verbose logging
+	Command   string // -c command (single execution)
+}
+
+// LoadConfig creates a Config with defaults, then overlays config file and env vars.
+func LoadConfig() *Config {
+	cfg := &Config{
+		Host:      "localhost",
+		AgentPort: 80,
+	}
+
+	// Layer 1: config file
+	cfg.loadConfigFile()
+
+	// Layer 2: environment variables
+	cfg.loadEnvVars()
+
+	return cfg
+}
+
+// ParseFlags extracts global flags from args and returns remaining args.
+// This is Layer 3 (highest priority).
+func (cfg *Config) ParseFlags(args []string) []string {
+	var remaining []string
+	i := 0
+	for i < len(args) {
+		switch args[i] {
+		case "-H", "--host":
+			if i+1 < len(args) {
+				cfg.Host = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: %s requires a value\n", args[i])
+				os.Exit(2)
+			}
+		case "--agent-port":
+			if i+1 < len(args) {
+				port, err := strconv.Atoi(args[i+1])
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error: invalid port: %s\n", args[i+1])
+					os.Exit(2)
+				}
+				cfg.AgentPort = port
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: --agent-port requires a value\n")
+				os.Exit(2)
+			}
+		case "-t", "--token":
+			if i+1 < len(args) {
+				cfg.Token = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: %s requires a value\n", args[i])
+				os.Exit(2)
+			}
+		case "-w", "--workgroup":
+			if i+1 < len(args) {
+				cfg.Workgroup = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: %s requires a value\n", args[i])
+				os.Exit(2)
+			}
+		case "-u", "--user":
+			if i+1 < len(args) {
+				cfg.User = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: %s requires a value\n", args[i])
+				os.Exit(2)
+			}
+		case "-c":
+			if i+1 < len(args) {
+				cfg.Command = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: -c requires a command\n")
+				os.Exit(2)
+			}
+		case "--json":
+			cfg.JSON = true
+			i++
+		case "--verbose":
+			cfg.Verbose = true
+			i++
+		case "--help", "-h":
+			printUsage()
+			os.Exit(0)
+		default:
+			// Not a global flag — stop parsing flags
+			remaining = append(remaining, args[i:]...)
+			return remaining
+		}
+	}
+	return remaining
+}
+
+// loadConfigFile reads ~/.dservctl if it exists.
+// Format: key: value (one per line, # comments)
+func (cfg *Config) loadConfigFile() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	path := filepath.Join(home, ".dservctl")
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		switch key {
+		case "host":
+			cfg.Host = value
+		case "agent-port":
+			if port, err := strconv.Atoi(value); err == nil {
+				cfg.AgentPort = port
+			}
+		case "token":
+			cfg.Token = value
+		case "workgroup":
+			cfg.Workgroup = value
+		case "user":
+			cfg.User = value
+		}
+	}
+}
+
+// loadEnvVars overlays environment variables
+func (cfg *Config) loadEnvVars() {
+	if v := os.Getenv("DSERV_HOST"); v != "" {
+		cfg.Host = v
+	}
+	if v := os.Getenv("DSERV_AGENT_PORT"); v != "" {
+		if port, err := strconv.Atoi(v); err == nil {
+			cfg.AgentPort = port
+		}
+	}
+	if v := os.Getenv("DSERV_AGENT_TOKEN"); v != "" {
+		cfg.Token = v
+	}
+	if v := os.Getenv("DSERV_WORKGROUP"); v != "" {
+		cfg.Workgroup = v
+	}
+	if v := os.Getenv("DSERV_USER"); v != "" {
+		cfg.User = v
+	}
+}
+
+// AgentBaseURL returns the base URL for agent HTTP API
+func (cfg *Config) AgentBaseURL() string {
+	return fmt.Sprintf("http://%s:%d", cfg.Host, cfg.AgentPort)
+}

--- a/tools/dservctl/config_test.go
+++ b/tools/dservctl/config_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfigDefaults(t *testing.T) {
+	// Clear env vars that might interfere
+	os.Unsetenv("DSERV_HOST")
+	os.Unsetenv("DSERV_AGENT_PORT")
+	os.Unsetenv("DSERV_AGENT_TOKEN")
+	os.Unsetenv("DSERV_WORKGROUP")
+	os.Unsetenv("DSERV_USER")
+
+	cfg := &Config{
+		Host:      "localhost",
+		AgentPort: 80,
+	}
+
+	if cfg.Host != "localhost" {
+		t.Errorf("default host = %q, want %q", cfg.Host, "localhost")
+	}
+	if cfg.AgentPort != 80 {
+		t.Errorf("default agent port = %d, want %d", cfg.AgentPort, 80)
+	}
+}
+
+func TestConfigEnvVars(t *testing.T) {
+	os.Setenv("DSERV_HOST", "myhost")
+	os.Setenv("DSERV_AGENT_PORT", "8080")
+	os.Setenv("DSERV_AGENT_TOKEN", "mytoken")
+	os.Setenv("DSERV_WORKGROUP", "mygroup")
+	os.Setenv("DSERV_USER", "myuser")
+	defer func() {
+		os.Unsetenv("DSERV_HOST")
+		os.Unsetenv("DSERV_AGENT_PORT")
+		os.Unsetenv("DSERV_AGENT_TOKEN")
+		os.Unsetenv("DSERV_WORKGROUP")
+		os.Unsetenv("DSERV_USER")
+	}()
+
+	cfg := &Config{
+		Host:      "localhost",
+		AgentPort: 80,
+	}
+	cfg.loadEnvVars()
+
+	if cfg.Host != "myhost" {
+		t.Errorf("host = %q, want %q", cfg.Host, "myhost")
+	}
+	if cfg.AgentPort != 8080 {
+		t.Errorf("agent port = %d, want %d", cfg.AgentPort, 8080)
+	}
+	if cfg.Token != "mytoken" {
+		t.Errorf("token = %q, want %q", cfg.Token, "mytoken")
+	}
+	if cfg.Workgroup != "mygroup" {
+		t.Errorf("workgroup = %q, want %q", cfg.Workgroup, "mygroup")
+	}
+	if cfg.User != "myuser" {
+		t.Errorf("user = %q, want %q", cfg.User, "myuser")
+	}
+}
+
+func TestConfigParseFlags(t *testing.T) {
+	cfg := &Config{
+		Host:      "localhost",
+		AgentPort: 80,
+	}
+
+	args := []string{"-H", "remotehost", "--json", "--verbose", "-c", "expr 2+2", "ess", "some_cmd"}
+	remaining := cfg.ParseFlags(args)
+
+	if cfg.Host != "remotehost" {
+		t.Errorf("host = %q, want %q", cfg.Host, "remotehost")
+	}
+	if !cfg.JSON {
+		t.Error("JSON flag should be true")
+	}
+	if !cfg.Verbose {
+		t.Error("Verbose flag should be true")
+	}
+	if cfg.Command != "expr 2+2" {
+		t.Errorf("command = %q, want %q", cfg.Command, "expr 2+2")
+	}
+	if len(remaining) != 2 || remaining[0] != "ess" || remaining[1] != "some_cmd" {
+		t.Errorf("remaining = %v, want [ess some_cmd]", remaining)
+	}
+}
+
+func TestAgentBaseURL(t *testing.T) {
+	cfg := &Config{Host: "rig1.local", AgentPort: 8080}
+	url := cfg.AgentBaseURL()
+	if url != "http://rig1.local:8080" {
+		t.Errorf("AgentBaseURL = %q, want %q", url, "http://rig1.local:8080")
+	}
+}

--- a/tools/dservctl/go.mod
+++ b/tools/dservctl/go.mod
@@ -1,0 +1,7 @@
+module dservctl
+
+go 1.21
+
+require github.com/chzyer/readline v1.5.1
+
+require golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect

--- a/tools/dservctl/go.sum
+++ b/tools/dservctl/go.sum
@@ -1,0 +1,8 @@
+github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
+github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
+github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
+github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
+github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/tools/dservctl/main.go
+++ b/tools/dservctl/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const version = "0.1.0"
+
+// Command represents a CLI subcommand
+type Command struct {
+	Name        string
+	Description string
+	Run         func(cfg *Config, args []string) int
+}
+
+var commands []Command
+
+func init() {
+	commands = []Command{
+		{"shell", "Interactive REPL with tab completion", runShell},
+		{"stim", "Send command to STIM (separate process, port 4612)", runStim},
+		{"status", "Show agent and dserv status", runStatus},
+		{"mesh", "List mesh nodes", runMesh},
+		{"service", "Control dserv service (start/stop/restart)", runService},
+		{"components", "List or install components", runComponents},
+		{"logs", "View service logs", runLogs},
+		{"systems", "List ESS systems in workgroup", runSystems},
+		{"scripts", "List scripts for a system", runScripts},
+		{"script", "Get or save a script", runScript},
+		{"history", "Show script version history", runHistory},
+		{"templates", "List or add templates", runTemplates},
+		{"sandbox", "Manage sandboxes (create/promote/sync/delete)", runSandbox},
+		{"export", "Export workgroup or system as ZIP", runExport},
+		{"sync", "Sync scripts with local directory", runSync},
+		{"version", "Show version", runVersion},
+		{"help", "Show help", nil},
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "dservctl %s - CLI for dserv + dserv-agent\n\n", version)
+	fmt.Fprintf(os.Stderr, "Usage:\n")
+	fmt.Fprintf(os.Stderr, "  dservctl [flags] [command] [args...]\n")
+	fmt.Fprintf(os.Stderr, "  dservctl [flags] <interpreter> [command]     Send to dserv interpreter\n")
+	fmt.Fprintf(os.Stderr, "  dservctl [flags] -c \"command\"                Send to dserv main interpreter\n\n")
+	fmt.Fprintf(os.Stderr, "Global flags:\n")
+	fmt.Fprintf(os.Stderr, "  -H, --host HOST        Target host (default: localhost, env: DSERV_HOST)\n")
+	fmt.Fprintf(os.Stderr, "  --agent-port PORT       Agent HTTP port (default: 80, env: DSERV_AGENT_PORT)\n")
+	fmt.Fprintf(os.Stderr, "  -t, --token TOKEN       Bearer token (env: DSERV_AGENT_TOKEN)\n")
+	fmt.Fprintf(os.Stderr, "  -w, --workgroup WG      Default workgroup (env: DSERV_WORKGROUP)\n")
+	fmt.Fprintf(os.Stderr, "  -u, --user USER         Username for registry ops (env: DSERV_USER)\n")
+	fmt.Fprintf(os.Stderr, "  --json                  Output JSON\n")
+	fmt.Fprintf(os.Stderr, "  --verbose               Verbose output\n\n")
+	fmt.Fprintf(os.Stderr, "Commands:\n")
+	maxLen := 0
+	for _, c := range commands {
+		if len(c.Name) > maxLen {
+			maxLen = len(c.Name)
+		}
+	}
+	for _, c := range commands {
+		fmt.Fprintf(os.Stderr, "  %-*s  %s\n", maxLen, c.Name, c.Description)
+	}
+	fmt.Fprintf(os.Stderr, "\nInterpreter commands (discovered dynamically from dserv):\n")
+	fmt.Fprintf(os.Stderr, "  dservctl ess \"command\"   Send to ESS subprocess\n")
+	fmt.Fprintf(os.Stderr, "  dservctl db \"command\"    Send to db subprocess\n")
+	fmt.Fprintf(os.Stderr, "  dservctl stim \"command\"  Send to STIM (direct, port 4612)\n\n")
+	fmt.Fprintf(os.Stderr, "Examples:\n")
+	fmt.Fprintf(os.Stderr, "  dservctl -c \"expr 2+2\"                       Direct to dserv interpreter\n")
+	fmt.Fprintf(os.Stderr, "  dservctl ess \"ess::status\"                    Send to ESS subprocess\n")
+	fmt.Fprintf(os.Stderr, "  echo \"expr 5*5\" | dservctl ess               Pipe to ESS\n")
+	fmt.Fprintf(os.Stderr, "  dservctl shell                                Interactive REPL\n")
+	fmt.Fprintf(os.Stderr, "  dservctl shell -s ess                         REPL targeting ESS\n")
+	fmt.Fprintf(os.Stderr, "  dservctl script get sys proto type > f.tcl    Download script\n")
+	fmt.Fprintf(os.Stderr, "  dservctl sandbox create sys mybranch          Create sandbox\n")
+}
+
+func main() {
+	cfg := LoadConfig()
+
+	// Parse global flags from os.Args
+	args := os.Args[1:]
+	args = cfg.ParseFlags(args)
+
+	if len(args) == 0 {
+		// No command: if stdin is piped, read commands; if -c was set, already handled; otherwise shell
+		if cfg.Command != "" {
+			// -c flag: send to dserv main interpreter
+			os.Exit(runDirectCommand(cfg, cfg.Command))
+		}
+		if isStdinPiped() {
+			os.Exit(runStdinCommands(cfg, ""))
+		}
+		// Interactive: launch shell
+		os.Exit(runShell(cfg, nil))
+	}
+
+	cmdName := args[0]
+	cmdArgs := args[1:]
+
+	// Check for help
+	if cmdName == "help" || cmdName == "--help" || cmdName == "-h" {
+		printUsage()
+		os.Exit(0)
+	}
+
+	// Check if it's a known command
+	for _, c := range commands {
+		if c.Name == cmdName {
+			if c.Run == nil {
+				printUsage()
+				os.Exit(0)
+			}
+			os.Exit(c.Run(cfg, cmdArgs))
+		}
+	}
+
+	// Not a known command — treat as interpreter name
+	// If there's a following argument, send it as a command
+	// If stdin is piped, read commands from stdin
+	// Otherwise, launch interactive shell for that interpreter
+	interp := cmdName
+	if len(cmdArgs) > 0 {
+		// Remaining args are joined as the command
+		cmd := strings.Join(cmdArgs, " ")
+		os.Exit(runInterpCommand(cfg, interp, cmd))
+	}
+	if isStdinPiped() {
+		os.Exit(runStdinCommands(cfg, interp))
+	}
+	// Interactive shell targeting this interpreter
+	os.Exit(runShell(cfg, []string{"-s", interp}))
+}
+
+func isStdinPiped() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) == 0
+}
+
+// runVersion prints version info
+func runVersion(cfg *Config, args []string) int {
+	fmt.Printf("dservctl %s\n", version)
+	return 0
+}

--- a/tools/dservctl/output.go
+++ b/tools/dservctl/output.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	errorPrefix    = "!TCL_ERROR "
+	errorPrefixLen = 11
+	ansiRed        = "\x1b[31m"
+	ansiReset      = "\x1b[0m"
+)
+
+// ProcessResponse checks for Tcl error prefix and returns the cleaned output and error status.
+func ProcessResponse(response string) (string, bool) {
+	if strings.HasPrefix(response, errorPrefix) {
+		return response[errorPrefixLen:], true
+	}
+	return response, false
+}
+
+// PrintResponse prints a response, handling errors with color when appropriate.
+func PrintResponse(response string, interactive bool) bool {
+	if response == "" {
+		return false
+	}
+	output, isError := ProcessResponse(response)
+	if isError {
+		if interactive && supportsColor() {
+			fmt.Printf("%s%s%s\n", ansiRed, output, ansiReset)
+		} else {
+			fmt.Println(output)
+		}
+		return true
+	}
+	if strings.TrimSpace(output) != "" {
+		fmt.Println(output)
+	}
+	return false
+}
+
+// supportsColor checks if the terminal supports ANSI colors.
+func supportsColor() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	if (fi.Mode() & os.ModeCharDevice) == 0 {
+		return false // not a terminal
+	}
+	return os.Getenv("TERM") != ""
+}
+
+// PrintTable prints a formatted table with headers and rows.
+func PrintTable(headers []string, rows [][]string) {
+	if len(rows) == 0 {
+		return
+	}
+
+	// Calculate column widths
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if i < len(widths) && len(cell) > widths[i] {
+				widths[i] = len(cell)
+			}
+		}
+	}
+
+	// Print header
+	for i, h := range headers {
+		if i > 0 {
+			fmt.Print("  ")
+		}
+		fmt.Printf("%-*s", widths[i], h)
+	}
+	fmt.Println()
+
+	// Print separator
+	for i, w := range widths {
+		if i > 0 {
+			fmt.Print("  ")
+		}
+		fmt.Print(strings.Repeat("-", w))
+	}
+	fmt.Println()
+
+	// Print rows
+	for _, row := range rows {
+		for i, cell := range row {
+			if i >= len(widths) {
+				break
+			}
+			if i > 0 {
+				fmt.Print("  ")
+			}
+			fmt.Printf("%-*s", widths[i], cell)
+		}
+		fmt.Println()
+	}
+}
+
+// PrintError prints an error message to stderr.
+func PrintError(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "Error: "+format+"\n", args...)
+}

--- a/tools/dservctl/registry.go
+++ b/tools/dservctl/registry.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// Registry API helper methods on AgentClient.
+// All registry endpoints live under /api/v1/ess/.
+
+const registryBase = "/api/v1/ess"
+
+// ListSystems returns systems for a workgroup.
+func (c *AgentClient) ListSystems(workgroup string) ([]map[string]interface{}, error) {
+	result, err := c.Get(registryBase + "/systems?workgroup=" + url.QueryEscape(workgroup))
+	if err != nil {
+		return nil, err
+	}
+	return extractList(result, "systems"), nil
+}
+
+// GetSystem returns a system with its scripts.
+func (c *AgentClient) GetSystem(workgroup, system, version string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/system/%s/%s", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	if version != "" {
+		path += "/" + url.PathEscape(version)
+	}
+	return c.Get(path)
+}
+
+// GetScripts returns scripts grouped by protocol.
+func (c *AgentClient) GetScripts(workgroup, system, version string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/scripts/%s/%s", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	if version != "" {
+		path += "?version=" + url.QueryEscape(version)
+	}
+	return c.Get(path)
+}
+
+// GetScript retrieves a single script.
+func (c *AgentClient) GetScript(workgroup, system, protocol, scriptType, version string) (map[string]interface{}, error) {
+	if protocol == "" || protocol == "_system" || protocol == "_" {
+		protocol = "_"
+	}
+	path := fmt.Sprintf("%s/script/%s/%s/%s/%s",
+		registryBase,
+		url.PathEscape(workgroup),
+		url.PathEscape(system),
+		url.PathEscape(protocol),
+		url.PathEscape(scriptType))
+	if version != "" {
+		path += "?version=" + url.QueryEscape(version)
+	}
+	return c.Get(path)
+}
+
+// SaveScript commits a script to the registry.
+func (c *AgentClient) SaveScript(workgroup, system, protocol, scriptType, version string, req map[string]interface{}) (map[string]interface{}, error) {
+	if protocol == "" || protocol == "_system" || protocol == "_" {
+		protocol = "_"
+	}
+	path := fmt.Sprintf("%s/script/%s/%s/%s/%s",
+		registryBase,
+		url.PathEscape(workgroup),
+		url.PathEscape(system),
+		url.PathEscape(protocol),
+		url.PathEscape(scriptType))
+	if version != "" {
+		path += "?version=" + url.QueryEscape(version)
+	}
+	return c.Do("PUT", path, req)
+}
+
+// DeleteScript deletes a script.
+func (c *AgentClient) DeleteScript(workgroup, system, protocol, scriptType string) (map[string]interface{}, error) {
+	if protocol == "" || protocol == "_system" || protocol == "_" {
+		protocol = "_"
+	}
+	path := fmt.Sprintf("%s/script/%s/%s/%s/%s",
+		registryBase,
+		url.PathEscape(workgroup),
+		url.PathEscape(system),
+		url.PathEscape(protocol),
+		url.PathEscape(scriptType))
+	return c.Do("DELETE", path, nil)
+}
+
+// GetHistory returns version history for a script.
+func (c *AgentClient) GetHistory(workgroup, system, protocol, scriptType string) (map[string]interface{}, error) {
+	if protocol == "" || protocol == "_system" || protocol == "_" {
+		protocol = "_"
+	}
+	path := fmt.Sprintf("%s/history/%s/%s/%s/%s",
+		registryBase,
+		url.PathEscape(workgroup),
+		url.PathEscape(system),
+		url.PathEscape(protocol),
+		url.PathEscape(scriptType))
+	return c.Get(path)
+}
+
+// ListTemplates returns the template zoo.
+func (c *AgentClient) ListTemplates() ([]map[string]interface{}, error) {
+	result, err := c.Get(registryBase + "/templates")
+	if err != nil {
+		return nil, err
+	}
+	return extractList(result, "systems"), nil
+}
+
+// AddToWorkgroup forks a template into a workgroup.
+func (c *AgentClient) AddToWorkgroup(templateSystem, targetWorkgroup, addedBy string) (map[string]interface{}, error) {
+	return c.Post(registryBase+"/add-to-workgroup", map[string]string{
+		"templateSystem":  templateSystem,
+		"templateVersion": "latest",
+		"targetWorkgroup": targetWorkgroup,
+		"addedBy":         addedBy,
+	})
+}
+
+// GetManifest returns checksums for a system (no content).
+func (c *AgentClient) GetManifest(workgroup, system, version string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/manifest/%s/%s", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	if version != "" {
+		path += "?version=" + url.QueryEscape(version)
+	}
+	return c.Get(path)
+}
+
+// SyncCheck posts local checksums and gets stale/extra scripts.
+func (c *AgentClient) SyncCheck(workgroup, system string, checksums map[string]string, version string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/sync/%s/%s", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	return c.Post(path, map[string]interface{}{
+		"checksums": checksums,
+		"version":   version,
+	})
+}
+
+// CreateSandbox creates a new sandbox version.
+func (c *AgentClient) CreateSandbox(workgroup, system, fromVersion, toVersion, username, comment string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/sandbox/%s/%s/create", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	return c.Post(path, map[string]string{
+		"fromVersion": fromVersion,
+		"toVersion":   toVersion,
+		"username":    username,
+		"comment":     comment,
+	})
+}
+
+// PromoteSandbox promotes a sandbox to a target version.
+func (c *AgentClient) PromoteSandbox(workgroup, system, fromVersion, toVersion, username, comment string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/sandbox/%s/%s/promote", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	return c.Post(path, map[string]string{
+		"fromVersion": fromVersion,
+		"toVersion":   toVersion,
+		"username":    username,
+		"comment":     comment,
+	})
+}
+
+// SyncSandbox pulls changes from a source version into a sandbox.
+func (c *AgentClient) SyncSandbox(workgroup, system, fromVersion, toVersion, username string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/sandbox/%s/%s/sync", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	return c.Post(path, map[string]string{
+		"fromVersion": fromVersion,
+		"toVersion":   toVersion,
+		"username":    username,
+		"conflicts":   "overwrite",
+	})
+}
+
+// DeleteSandbox removes a sandbox version.
+func (c *AgentClient) DeleteSandbox(workgroup, system, version string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/sandbox/%s/%s/%s",
+		registryBase,
+		url.PathEscape(workgroup),
+		url.PathEscape(system),
+		url.PathEscape(version))
+	return c.Do("DELETE", path, nil)
+}
+
+// ListVersions returns all versions of a system.
+func (c *AgentClient) ListVersions(workgroup, system string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("%s/sandbox/%s/%s/versions", registryBase, url.PathEscape(workgroup), url.PathEscape(system))
+	return c.Get(path)
+}
+
+// ExportZip downloads a workgroup or system as ZIP.
+func (c *AgentClient) ExportZip(workgroup, system string) ([]byte, error) {
+	path := fmt.Sprintf("%s/export/%s", registryBase, url.PathEscape(workgroup))
+	if system != "" {
+		path += "/" + url.PathEscape(system)
+	}
+	path += "?format=zip"
+	data, _, err := c.GetRaw(path)
+	return data, err
+}
+
+// --- helpers ---
+
+func extractList(result map[string]interface{}, key string) []map[string]interface{} {
+	if items, ok := result[key].([]interface{}); ok {
+		return toMapSlice(items)
+	}
+	// Try "items" (from array wrapper)
+	if items, ok := result["items"].([]interface{}); ok {
+		return toMapSlice(items)
+	}
+	return nil
+}
+
+func mustJSON(v interface{}) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}

--- a/tools/dservctl/shell.go
+++ b/tools/dservctl/shell.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chzyer/readline"
+)
+
+// DservCompleter implements readline.AutoCompleter using the backend complete_token command.
+type DservCompleter struct {
+	host   string
+	interp string // current target interpreter ("" = dserv direct)
+}
+
+func (c *DservCompleter) Do(line []rune, pos int) ([][]rune, int) {
+	// Only complete at end of line
+	input := string(line[:pos])
+	if input == "" {
+		return nil, 0
+	}
+
+	// Build completion command
+	var completeCmd string
+	if c.interp == "" || c.interp == "dserv" {
+		completeCmd = fmt.Sprintf("complete_token {%s}", input)
+	} else {
+		completeCmd = fmt.Sprintf("send %s {complete_token {%s}}", c.interp, input)
+	}
+
+	// Send to dserv
+	resp, err := SendToDserv(c.host, completeCmd)
+	if err != nil || resp == "" {
+		return nil, 0
+	}
+
+	// Parse Tcl list response
+	matches := ParseTclList(resp)
+	if len(matches) == 0 {
+		return nil, 0
+	}
+
+	// Find the last token being completed
+	lastSpace := strings.LastIndexAny(input, " \t")
+	partial := input
+	if lastSpace >= 0 {
+		partial = input[lastSpace+1:]
+	}
+
+	// Build completion candidates (what readline needs to append)
+	var candidates [][]rune
+	for _, match := range matches {
+		if strings.HasPrefix(match, partial) {
+			suffix := match[len(partial):]
+			candidates = append(candidates, []rune(suffix))
+		} else {
+			// If match doesn't start with partial, offer the full match
+			candidates = append(candidates, []rune(match))
+		}
+	}
+
+	return candidates, len(partial)
+}
+
+func runShell(cfg *Config, args []string) int {
+	// Parse shell-specific flags
+	interp := ""
+	for i := 0; args != nil && i < len(args); i++ {
+		switch args[i] {
+		case "-s":
+			if i+1 < len(args) {
+				interp = args[i+1]
+				i++
+			}
+		}
+	}
+
+	// Discover available interpreters
+	availInterps, err := DiscoverInterpreters(cfg.Host)
+	if err != nil && cfg.Verbose {
+		fmt.Fprintf(os.Stderr, "Warning: could not discover interpreters: %v\n", err)
+	}
+
+	// Build prompt
+	prompt := promptForInterp(interp)
+
+	completer := &DservCompleter{
+		host:   cfg.Host,
+		interp: interp,
+	}
+
+	// History file
+	historyFile := filepath.Join(homeDir(), ".dservctl_history")
+
+	rl, err := readline.NewEx(&readline.Config{
+		Prompt:            prompt,
+		HistoryFile:       historyFile,
+		AutoComplete:      completer,
+		InterruptPrompt:   "^C",
+		EOFPrompt:         "exit",
+		HistorySearchFold: true,
+	})
+	if err != nil {
+		PrintError("initializing readline: %v", err)
+		return 1
+	}
+	defer rl.Close()
+
+	if cfg.Verbose {
+		fmt.Fprintf(os.Stderr, "Connected to %s:%d\n", cfg.Host, DservPort)
+		if len(availInterps) > 0 {
+			fmt.Fprintf(os.Stderr, "Available interpreters: %s\n", strings.Join(availInterps, ", "))
+		}
+		fmt.Fprintf(os.Stderr, "Type /help for commands, exit to quit\n")
+	}
+
+	for {
+		line, err := rl.Readline()
+		if err == readline.ErrInterrupt {
+			continue
+		}
+		if err == io.EOF {
+			break
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if line == "exit" || line == "quit" {
+			break
+		}
+
+		// Handle meta-commands starting with /
+		if strings.HasPrefix(line, "/") {
+			handled := handleMetaCommand(rl, completer, cfg, line, availInterps)
+			if handled {
+				continue
+			}
+		}
+
+		// Send command to current interpreter
+		resp, err := Send(cfg.Host, interp, line)
+		if err != nil {
+			PrintError("%v", err)
+			continue
+		}
+		PrintResponse(resp, true)
+	}
+
+	return 0
+}
+
+// handleMetaCommand processes /commands in the shell. Returns true if handled.
+func handleMetaCommand(rl *readline.Instance, completer *DservCompleter, cfg *Config, line string, availInterps []string) bool {
+	parts := strings.SplitN(line, " ", 2)
+	cmd := parts[0]
+
+	switch cmd {
+	case "/help":
+		fmt.Println("Shell commands:")
+		fmt.Println("  /dserv            Switch to dserv main interpreter")
+		fmt.Println("  /<interp>         Switch to interpreter (e.g., /ess, /db, /pg)")
+		fmt.Println("  /<interp> cmd     Send one command to interpreter without switching")
+		fmt.Println("  /interps          List available interpreters")
+		fmt.Println("  /help             Show this help")
+		fmt.Println("  exit              Exit shell")
+		return true
+
+	case "/interps":
+		interps, err := DiscoverInterpreters(cfg.Host)
+		if err != nil {
+			PrintError("discovering interpreters: %v", err)
+		} else {
+			fmt.Println("dserv (main)")
+			for _, name := range interps {
+				fmt.Printf("  %s\n", name)
+			}
+			fmt.Println("stim (direct, port 4612)")
+		}
+		return true
+
+	case "/dserv":
+		if len(parts) > 1 {
+			// One-off command to dserv
+			resp, err := SendToDserv(cfg.Host, parts[1])
+			if err != nil {
+				PrintError("%v", err)
+			} else {
+				PrintResponse(resp, true)
+			}
+		} else {
+			completer.interp = ""
+			rl.SetPrompt(promptForInterp(""))
+		}
+		return true
+	}
+
+	// Check if it's an interpreter switch: /ess, /db, etc.
+	interpName := cmd[1:] // strip leading /
+	if interpName == "stim" || isKnownInterp(interpName, availInterps) {
+		if len(parts) > 1 {
+			// One-off command
+			resp, err := Send(cfg.Host, interpName, parts[1])
+			if err != nil {
+				PrintError("%v", err)
+			} else {
+				PrintResponse(resp, true)
+			}
+		} else {
+			// Switch interpreter
+			completer.interp = interpName
+			rl.SetPrompt(promptForInterp(interpName))
+		}
+		return true
+	}
+
+	fmt.Printf("Unknown command: %s (use /help for available commands)\n", cmd)
+	return true
+}
+
+func isKnownInterp(name string, interps []string) bool {
+	for _, i := range interps {
+		if i == name {
+			return true
+		}
+	}
+	return false
+}
+
+func promptForInterp(interp string) string {
+	if interp == "" || interp == "dserv" {
+		return "dserv> "
+	}
+	return interp + "> "
+}
+
+func homeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	return home
+}

--- a/tools/dservctl/tcllist.go
+++ b/tools/dservctl/tcllist.go
@@ -1,0 +1,116 @@
+package main
+
+// ParseTclList parses a Tcl list string into individual elements.
+// Handles brace-grouping {word with spaces}, double-quoted "word", and bare words.
+func ParseTclList(input string) []string {
+	var result []string
+	input = trimSpace(input)
+	i := 0
+	for i < len(input) {
+		// Skip whitespace
+		for i < len(input) && (input[i] == ' ' || input[i] == '\t') {
+			i++
+		}
+		if i >= len(input) {
+			break
+		}
+
+		var elem string
+		switch input[i] {
+		case '{':
+			elem, i = parseBraced(input, i)
+		case '"':
+			elem, i = parseQuoted(input, i)
+		default:
+			elem, i = parseBare(input, i)
+		}
+		result = append(result, elem)
+	}
+	return result
+}
+
+// parseBraced extracts a brace-grouped element: {content}
+func parseBraced(s string, start int) (string, int) {
+	i := start + 1 // skip opening brace
+	depth := 1
+	var buf []byte
+	for i < len(s) && depth > 0 {
+		if s[i] == '{' {
+			depth++
+			buf = append(buf, s[i])
+		} else if s[i] == '}' {
+			depth--
+			if depth > 0 {
+				buf = append(buf, s[i])
+			}
+		} else if s[i] == '\\' && i+1 < len(s) {
+			// In braces, only \newline is special; pass everything else literally
+			buf = append(buf, s[i])
+			i++
+			buf = append(buf, s[i])
+		} else {
+			buf = append(buf, s[i])
+		}
+		i++
+	}
+	return string(buf), i
+}
+
+// parseQuoted extracts a double-quoted element: "content"
+func parseQuoted(s string, start int) (string, int) {
+	i := start + 1 // skip opening quote
+	var buf []byte
+	for i < len(s) {
+		if s[i] == '"' {
+			i++ // skip closing quote
+			return string(buf), i
+		}
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+			switch s[i] {
+			case 'n':
+				buf = append(buf, '\n')
+			case 't':
+				buf = append(buf, '\t')
+			case '\\':
+				buf = append(buf, '\\')
+			case '"':
+				buf = append(buf, '"')
+			default:
+				buf = append(buf, '\\', s[i])
+			}
+		} else {
+			buf = append(buf, s[i])
+		}
+		i++
+	}
+	return string(buf), i
+}
+
+// parseBare extracts a bare word (whitespace-delimited)
+func parseBare(s string, start int) (string, int) {
+	i := start
+	var buf []byte
+	for i < len(s) && s[i] != ' ' && s[i] != '\t' && s[i] != '\n' {
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+			buf = append(buf, s[i])
+		} else {
+			buf = append(buf, s[i])
+		}
+		i++
+	}
+	return string(buf), i
+}
+
+func trimSpace(s string) string {
+	start := 0
+	for start < len(s) && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r') {
+		start++
+	}
+	end := len(s)
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r') {
+		end--
+	}
+	return s[start:end]
+}

--- a/tools/dservctl/tcllist_test.go
+++ b/tools/dservctl/tcllist_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTclListBareWords(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"", nil},
+		{"hello", []string{"hello"}},
+		{"hello world", []string{"hello", "world"}},
+		{"  hello   world  ", []string{"hello", "world"}},
+		{"one two three", []string{"one", "two", "three"}},
+	}
+	for _, tt := range tests {
+		got := ParseTclList(tt.input)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("ParseTclList(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseTclListBraced(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"{hello world}", []string{"hello world"}},
+		{"{hello} {world}", []string{"hello", "world"}},
+		{"{info commands} {info complete} {info coroutine}", []string{"info commands", "info complete", "info coroutine"}},
+		{"foo {bar baz} qux", []string{"foo", "bar baz", "qux"}},
+		{"{nested {braces}}", []string{"nested {braces}"}},
+	}
+	for _, tt := range tests {
+		got := ParseTclList(tt.input)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("ParseTclList(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseTclListQuoted(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{`"hello world"`, []string{"hello world"}},
+		{`"hello" "world"`, []string{"hello", "world"}},
+		{`"escaped \"quote\""`, []string{`escaped "quote"`}},
+		{`"tab\there"`, []string{"tab\there"}},
+	}
+	for _, tt := range tests {
+		got := ParseTclList(tt.input)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("ParseTclList(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseTclListMixed(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{`foo {bar baz} "hello world" qux`, []string{"foo", "bar baz", "hello world", "qux"}},
+		{`commands complete coroutine`, []string{"commands", "complete", "coroutine"}},
+	}
+	for _, tt := range tests {
+		got := ParseTclList(tt.input)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("ParseTclList(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseTclListCompletionResponse(t *testing.T) {
+	// Typical completion responses from complete_token
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		// Simple word list (most common for complete_token)
+		{"commands complete coroutine", []string{"commands", "complete", "coroutine"}},
+		// Braced list (from complete command)
+		{"{set tcl_platform} {set tcl_patchLevel}", []string{"set tcl_platform", "set tcl_patchLevel"}},
+		// Single match
+		{"hostname", []string{"hostname"}},
+		// Empty
+		{"", nil},
+	}
+	for _, tt := range tests {
+		got := ParseTclList(tt.input)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("ParseTclList(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}

--- a/tools/dservctl/tcp.go
+++ b/tools/dservctl/tcp.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	DservPort      = 2560
+	STIMPort       = 4612
+	ConnectTimeout = 5 * time.Second
+	ReadTimeout    = 30 * time.Second
+)
+
+// SendBinary sends a command using the binary message protocol (4-byte length prefix).
+// Used for dserv (port 2560) and STIM (port 4612).
+func SendBinary(host string, port int, msg string) (string, error) {
+	addr := fmt.Sprintf("%s:%d", host, port)
+	conn, err := net.DialTimeout("tcp", addr, ConnectTimeout)
+	if err != nil {
+		return "", fmt.Errorf("connection to %s failed: %w", addr, err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(ReadTimeout))
+
+	msgBytes := []byte(msg)
+
+	// Send: 4-byte big-endian length + body
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(msgBytes)))
+	if _, err := conn.Write(lenBuf); err != nil {
+		return "", fmt.Errorf("write length failed: %w", err)
+	}
+	if _, err := conn.Write(msgBytes); err != nil {
+		return "", fmt.Errorf("write body failed: %w", err)
+	}
+
+	// Receive: 4-byte big-endian length + body
+	var respLen uint32
+	if err := binary.Read(conn, binary.BigEndian, &respLen); err != nil {
+		return "", fmt.Errorf("read response length failed: %w", err)
+	}
+
+	respBuf := make([]byte, respLen)
+	if _, err := io.ReadFull(conn, respBuf); err != nil {
+		return "", fmt.Errorf("read response body failed: %w", err)
+	}
+
+	return string(respBuf), nil
+}
+
+// SendToDserv sends a command directly to the dserv main interpreter (port 2560).
+func SendToDserv(host string, cmd string) (string, error) {
+	return SendBinary(host, DservPort, cmd)
+}
+
+// SendToInterp sends a command to a dserv subprocess via `send <interp> {cmd}`.
+// Routes through the dserv main interpreter on port 2560.
+func SendToInterp(host string, interp string, cmd string) (string, error) {
+	wrapped := fmt.Sprintf("send %s {%s}", interp, cmd)
+	return SendBinary(host, DservPort, wrapped)
+}
+
+// SendToSTIM sends a command directly to the STIM process (port 4612).
+func SendToSTIM(host string, cmd string) (string, error) {
+	return SendBinary(host, STIMPort, cmd)
+}
+
+// Send dispatches a command to the appropriate target.
+// If interp is empty, sends directly to dserv.
+// If interp is "stim", sends directly to STIM port.
+// Otherwise, wraps with send command.
+func Send(host string, interp string, cmd string) (string, error) {
+	switch interp {
+	case "", "dserv":
+		return SendToDserv(host, cmd)
+	case "stim":
+		return SendToSTIM(host, cmd)
+	default:
+		return SendToInterp(host, interp, cmd)
+	}
+}
+
+// DiscoverInterpreters queries the dserv/interps datapoint to get available subprocesses.
+func DiscoverInterpreters(host string) ([]string, error) {
+	resp, err := SendToDserv(host, "dpget dserv/interps")
+	if err != nil {
+		return nil, err
+	}
+	resp = strings.TrimSpace(resp)
+	if resp == "" {
+		return nil, nil
+	}
+	interps := strings.Fields(resp)
+	return interps, nil
+}
+
+// TestConnection verifies dserv is reachable on port 2560.
+func TestConnection(host string) error {
+	_, err := SendToDserv(host, "expr {2+2}")
+	return err
+}

--- a/tools/dservctl/tcp_test.go
+++ b/tools/dservctl/tcp_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// startMockBinaryServer creates a TCP server that echoes using the binary protocol.
+func startMockBinaryServer(t *testing.T, response string) (int, func()) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start mock server: %v", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+
+				// Read incoming binary message
+				var msgLen uint32
+				if err := binary.Read(c, binary.BigEndian, &msgLen); err != nil {
+					return
+				}
+				buf := make([]byte, msgLen)
+				if _, err := io.ReadFull(c, buf); err != nil {
+					return
+				}
+
+				// Send response using binary protocol
+				respBytes := []byte(response)
+				respLen := make([]byte, 4)
+				binary.BigEndian.PutUint32(respLen, uint32(len(respBytes)))
+				c.Write(respLen)
+				c.Write(respBytes)
+			}(conn)
+		}
+	}()
+
+	return port, func() { listener.Close() }
+}
+
+func TestSendBinary(t *testing.T) {
+	port, cleanup := startMockBinaryServer(t, "4")
+	defer cleanup()
+
+	time.Sleep(10 * time.Millisecond) // Let server start
+
+	resp, err := SendBinary("127.0.0.1", port, "expr 2+2")
+	if err != nil {
+		t.Fatalf("SendBinary failed: %v", err)
+	}
+	if resp != "4" {
+		t.Errorf("SendBinary response = %q, want %q", resp, "4")
+	}
+}
+
+func TestSendBinaryLargeMessage(t *testing.T) {
+	expected := "hello world this is a longer response with more content"
+	port, cleanup := startMockBinaryServer(t, expected)
+	defer cleanup()
+
+	time.Sleep(10 * time.Millisecond)
+
+	resp, err := SendBinary("127.0.0.1", port, "some command")
+	if err != nil {
+		t.Fatalf("SendBinary failed: %v", err)
+	}
+	if resp != expected {
+		t.Errorf("SendBinary response = %q, want %q", resp, expected)
+	}
+}
+
+func TestSendBinaryConnectionRefused(t *testing.T) {
+	_, err := SendBinary("127.0.0.1", 19999, "test")
+	if err == nil {
+		t.Error("expected error for connection refused, got nil")
+	}
+}
+
+func TestProcessResponse(t *testing.T) {
+	tests := []struct {
+		input   string
+		output  string
+		isError bool
+	}{
+		{"hello", "hello", false},
+		{"", "", false},
+		{"!TCL_ERROR invalid command", "invalid command", true},
+		{"!TCL_ERROR ", "", true},
+		{"normal response", "normal response", false},
+	}
+	for _, tt := range tests {
+		output, isError := ProcessResponse(tt.input)
+		if output != tt.output || isError != tt.isError {
+			t.Errorf("ProcessResponse(%q) = (%q, %v), want (%q, %v)",
+				tt.input, output, isError, tt.output, tt.isError)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New Go CLI tool (`tools/dservctl/`) that replaces essctrl and adds dserv-agent + ESS registry support
- Three communication paths: binary protocol to dserv (port 2560) with send-based subprocess routing, direct STIM (port 4612), and HTTP REST to dserv-agent
- Interactive REPL with readline, tab completion via backend `complete_token`, dynamic interpreter discovery, and service switching (`/ess`, `/db`, `/pg`)
- Agent commands: `status`, `mesh`, `service`, `components`, `logs`
- Registry commands: `systems`, `scripts`, `script get/save/delete`, `history`, `templates`, `sandbox` (create/promote/sync/delete/versions), `export`, `sync`
- 18 source files, 3198 lines, 13 passing tests

## File Layout
```
tools/dservctl/
  main.go           # Entry point, command dispatch
  config.go         # Config: env vars, config file, flags
  tcp.go            # Binary protocol + send-based routing
  agent.go          # HTTP client for dserv-agent REST API
  registry.go       # ESS registry API client methods
  cmd_interp.go     # Interpreter commands (direct, stdin, stim)
  cmd_agent.go      # status, mesh, service, components, logs
  cmd_registry.go   # systems, scripts, script, history, templates, export
  cmd_sandbox.go    # sandbox create/promote/sync/delete/versions
  cmd_sync.go       # Manifest-based sync with local directory
  shell.go          # Interactive REPL with readline + tab completion
  output.go         # Table formatting, JSON, colored errors
  tcllist.go        # Tcl list parser for completion results
  *_test.go         # Unit tests (config, tcp, tcllist)
```

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (13 tests)
- [x] CLI usage messages display correctly for all commands
- [ ] Verify `dservctl -c "expr 2+2"` against live dserv
- [ ] Verify `dservctl shell` interactive mode with tab completion
- [ ] Verify `dservctl status` / `dservctl mesh` against live dserv-agent
- [ ] Verify registry commands against live ESS registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)