### PR TITLE
dservctl: add datapoint commands and fix dservGet

### DIFF
--- a/tools/dservctl/cmd_datapoint.go
+++ b/tools/dservctl/cmd_datapoint.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runGet retrieves a datapoint value via dservGet.
+func runGet(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl get <datapoint>\n")
+		return 2
+	}
+
+	cmd := "dservGet " + args[0]
+	resp, err := SendToDserv(cfg.Host, cmd)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	output, isError := ProcessResponse(resp)
+	if isError {
+		PrintError("%s", output)
+		return 1
+	}
+	fmt.Println(output)
+	return 0
+}
+
+// runSet sets a datapoint value via dservSet.
+func runSet(cfg *Config, args []string) int {
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl set <datapoint> <value>\n")
+		return 2
+	}
+
+	value := strings.Join(args[1:], " ")
+	cmd := fmt.Sprintf("dservSet %s {%s}", args[0], value)
+	resp, err := SendToDserv(cfg.Host, cmd)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	output, isError := ProcessResponse(resp)
+	if isError {
+		PrintError("%s", output)
+		return 1
+	}
+	if cfg.Verbose && output != "" {
+		fmt.Println(output)
+	}
+	return 0
+}
+
+// runTouch triggers subscriber notification for a datapoint via dservTouch.
+func runTouch(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl touch <datapoint>\n")
+		return 2
+	}
+
+	cmd := "dservTouch " + args[0]
+	resp, err := SendToDserv(cfg.Host, cmd)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	output, isError := ProcessResponse(resp)
+	if isError {
+		PrintError("%s", output)
+		return 1
+	}
+	if cfg.Verbose && output != "" {
+		fmt.Println(output)
+	}
+	return 0
+}
+
+// runClear clears datapoint(s) via dservClear.
+func runClear(cfg *Config, args []string) int {
+	var cmd string
+	if len(args) == 0 {
+		cmd = "dservClear"
+	} else {
+		cmd = "dservClear " + strings.Join(args, " ")
+	}
+
+	resp, err := SendToDserv(cfg.Host, cmd)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	output, isError := ProcessResponse(resp)
+	if isError {
+		PrintError("%s", output)
+		return 1
+	}
+	if cfg.Verbose && output != "" {
+		fmt.Println(output)
+	}
+	return 0
+}

--- a/tools/dservctl/main.go
+++ b/tools/dservctl/main.go
@@ -21,6 +21,10 @@ func init() {
 	commands = []Command{
 		{"shell", "Interactive REPL with tab completion", runShell},
 		{"stim", "Send command to STIM (separate process, port 4612)", runStim},
+		{"get", "Get a datapoint value (dservGet)", runGet},
+		{"set", "Set a datapoint value (dservSet)", runSet},
+		{"touch", "Touch a datapoint (notify subscribers)", runTouch},
+		{"clear", "Clear datapoint(s) (dservClear)", runClear},
 		{"status", "Show agent and dserv status", runStatus},
 		{"mesh", "List mesh nodes", runMesh},
 		{"service", "Control dserv service (start/stop/restart)", runService},
@@ -73,6 +77,9 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  echo \"expr 5*5\" | dservctl ess               Pipe to ESS\n")
 	fmt.Fprintf(os.Stderr, "  dservctl shell                                Interactive REPL\n")
 	fmt.Fprintf(os.Stderr, "  dservctl shell -s ess                         REPL targeting ESS\n")
+	fmt.Fprintf(os.Stderr, "  dservctl get ess/status                       Get a datapoint value\n")
+	fmt.Fprintf(os.Stderr, "  dservctl set ess/state running                Set a datapoint value\n")
+	fmt.Fprintf(os.Stderr, "  dservctl touch ess/em_pos                    Touch (notify subscribers)\n")
 	fmt.Fprintf(os.Stderr, "  dservctl script get sys proto type > f.tcl    Download script\n")
 	fmt.Fprintf(os.Stderr, "  dservctl sandbox create sys mybranch          Create sandbox\n")
 }

--- a/tools/dservctl/tcp.go
+++ b/tools/dservctl/tcp.go
@@ -87,7 +87,7 @@ func Send(host string, interp string, cmd string) (string, error) {
 
 // DiscoverInterpreters queries the dserv/interps datapoint to get available subprocesses.
 func DiscoverInterpreters(host string) ([]string, error) {
-	resp, err := SendToDserv(host, "dpget dserv/interps")
+	resp, err := SendToDserv(host, "dservGet dserv/interps")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Add convenience CLI commands for common dserv datapoint operations: `get`, `set`, `touch`, `clear`
- Fix `DiscoverInterpreters` to use the correct `dservGet` Tcl command instead of non-existent `dpget`

## Usage
```
dservctl get ess/status           # retrieve datapoint value
dservctl set ess/state running    # set datapoint value
dservctl touch ess/em_pos         # notify subscribers
dservctl clear ess/old_dp         # clear specific datapoint
dservctl clear                    # clear all datapoints
```

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (13 tests)
- [ ] Verify `dservctl get dserv/interps` returns interpreter list on live system
- [ ] Verify `dservctl set`/`touch`/`clear` against live dserv

🤖 Generated with [Claude Code](https://claude.com/claude-code)