### PR TITLE
dservctl: add listen command and fix stim completion

### DIFF
--- a/tools/dservctl/cmd_listen.go
+++ b/tools/dservctl/cmd_listen.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	sendJSON = 2
+)
+
+// Datapoint represents a JSON datapoint update from dserv.
+type Datapoint struct {
+	Name      string          `json:"name"`
+	Timestamp uint64          `json:"timestamp"`
+	Dtype     uint32          `json:"dtype"`
+	Data      json.RawMessage `json:"data"`
+}
+
+// runListen subscribes to datapoint updates and prints them as they arrive.
+func runListen(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl listen <pattern> [pattern...]\n")
+		fmt.Fprintf(os.Stderr, "\nPatterns support wildcards: * (any chars), ? (single char)\n")
+		fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		fmt.Fprintf(os.Stderr, "  dservctl listen \"ess/*\"                Watch all ess datapoints\n")
+		fmt.Fprintf(os.Stderr, "  dservctl listen \"ess/state\"            Watch a single datapoint\n")
+		fmt.Fprintf(os.Stderr, "  dservctl listen \"ess/*\" \"print\"        Watch multiple patterns\n")
+		fmt.Fprintf(os.Stderr, "  dservctl listen \"*\"                    Watch everything\n")
+		return 2
+	}
+
+	// Start local TCP listener on random port
+	listener, err := net.Listen("tcp4", ":0")
+	if err != nil {
+		PrintError("failed to start listener: %v", err)
+		return 1
+	}
+	defer listener.Close()
+
+	_, listenPort, _ := net.SplitHostPort(listener.Addr().String())
+
+	// Determine our IP as seen by the dserv host
+	localIP, err := GetLocalIP(cfg.Host)
+	if err != nil {
+		PrintError("cannot reach dserv text port on %s:%d: %v", cfg.Host, DservTextPort, err)
+		return 1
+	}
+
+	if cfg.Verbose {
+		fmt.Fprintf(os.Stderr, "Listening on %s:%s\n", localIP, listenPort)
+	}
+
+	// Register with dserv for JSON updates
+	regCmd := fmt.Sprintf("%%reg %s %s %d", localIP, listenPort, sendJSON)
+	_, err = SendText(cfg.Host, DservTextPort, regCmd)
+	if err != nil {
+		PrintError("failed to register: %v", err)
+		return 1
+	}
+
+	// Add match patterns
+	for _, pattern := range args {
+		matchCmd := fmt.Sprintf("%%match %s %s %s 1", localIP, listenPort, pattern)
+		_, err = SendText(cfg.Host, DservTextPort, matchCmd)
+		if err != nil {
+			PrintError("failed to add match %q: %v", pattern, err)
+			return 1
+		}
+		if cfg.Verbose {
+			fmt.Fprintf(os.Stderr, "Subscribed to %q\n", pattern)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Listening for datapoints on %s (Ctrl-C to stop)...\n", cfg.Host)
+
+	// Handle Ctrl-C gracefully
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Accept connections and print datapoints
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go handleDatapointConn(conn, cfg.JSON)
+		}
+	}()
+
+	// Wait for signal
+	<-sigCh
+	fmt.Fprintf(os.Stderr, "\nStopped.\n")
+	listener.Close()
+	return 0
+}
+
+// handleDatapointConn reads newline-terminated JSON datapoints from a connection.
+func handleDatapointConn(conn net.Conn, jsonOutput bool) {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+
+		line = []byte(strings.TrimSpace(string(line)))
+		if len(line) == 0 {
+			continue
+		}
+
+		if jsonOutput {
+			// Pass through raw JSON
+			fmt.Println(string(line))
+			continue
+		}
+
+		// Parse and format nicely
+		var dp Datapoint
+		if err := json.Unmarshal(line, &dp); err != nil {
+			fmt.Println(string(line))
+			continue
+		}
+
+		formatDatapoint(dp)
+	}
+}
+
+// formatDatapoint prints a human-readable datapoint update.
+func formatDatapoint(dp Datapoint) {
+	ts := time.UnixMicro(int64(dp.Timestamp))
+	timeStr := ts.Format("15:04:05.000")
+
+	// Try to decode the data field
+	dataStr := decodeData(dp.Dtype, dp.Data)
+
+	fmt.Printf("%s  %-30s  %s\n", timeStr, dp.Name, dataStr)
+}
+
+// decodeData extracts a human-readable string from the data field.
+func decodeData(dtype uint32, raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	// Try as string first (base64 encoded data comes as a quoted string)
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		switch dtype {
+		case 1: // STRING
+			// base64-encoded string - decode it
+			if decoded, err := base64.StdEncoding.DecodeString(s); err == nil {
+				return string(decoded)
+			}
+			return s
+		default:
+			// For other types, try base64 decode, fall back to raw
+			if decoded, err := base64.StdEncoding.DecodeString(s); err == nil {
+				return string(decoded)
+			}
+			return s
+		}
+	}
+
+	// Try as number
+	var f float64
+	if err := json.Unmarshal(raw, &f); err == nil {
+		return fmt.Sprintf("%g", f)
+	}
+
+	// Fall back to raw JSON
+	return string(raw)
+}

--- a/tools/dservctl/main.go
+++ b/tools/dservctl/main.go
@@ -25,6 +25,7 @@ func init() {
 		{"set", "Set a datapoint value (dservSet)", runSet},
 		{"touch", "Touch a datapoint (notify subscribers)", runTouch},
 		{"clear", "Clear datapoint(s) (dservClear)", runClear},
+		{"listen", "Subscribe to datapoint updates", runListen},
 		{"status", "Show agent and dserv status", runStatus},
 		{"mesh", "List mesh nodes", runMesh},
 		{"service", "Control dserv service (start/stop/restart)", runService},
@@ -80,6 +81,7 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  dservctl get ess/status                       Get a datapoint value\n")
 	fmt.Fprintf(os.Stderr, "  dservctl set ess/state running                Set a datapoint value\n")
 	fmt.Fprintf(os.Stderr, "  dservctl touch ess/em_pos                    Touch (notify subscribers)\n")
+	fmt.Fprintf(os.Stderr, "  dservctl listen \"ess/*\"                       Stream datapoint updates\n")
 	fmt.Fprintf(os.Stderr, "  dservctl script get sys proto type > f.tcl    Download script\n")
 	fmt.Fprintf(os.Stderr, "  dservctl sandbox create sys mybranch          Create sandbox\n")
 }

--- a/tools/dservctl/shell.go
+++ b/tools/dservctl/shell.go
@@ -23,16 +23,21 @@ func (c *DservCompleter) Do(line []rune, pos int) ([][]rune, int) {
 		return nil, 0
 	}
 
-	// Build completion command
-	var completeCmd string
+	// Build and send completion command
+	completeCmd := fmt.Sprintf("complete_token {%s}", input)
+	var resp string
+	var err error
 	if c.interp == "" || c.interp == "dserv" {
-		completeCmd = fmt.Sprintf("complete_token {%s}", input)
+		// Direct to dserv main interpreter
+		resp, err = SendToDserv(c.host, completeCmd)
+	} else if c.interp == "stim" {
+		// Direct to STIM process (port 4612) — not a dserv subprocess
+		resp, err = SendToSTIM(c.host, completeCmd)
 	} else {
-		completeCmd = fmt.Sprintf("send %s {complete_token {%s}}", c.interp, input)
+		// Route through dserv via send
+		wrapped := fmt.Sprintf("send %s {%s}", c.interp, completeCmd)
+		resp, err = SendToDserv(c.host, wrapped)
 	}
-
-	// Send to dserv
-	resp, err := SendToDserv(c.host, completeCmd)
 	if err != nil || resp == "" {
 		return nil, 0
 	}

--- a/tools/dservctl/tcp.go
+++ b/tools/dservctl/tcp.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	DservPort      = 2560
+	DservTextPort  = 4620
 	STIMPort       = 4612
 	ConnectTimeout = 5 * time.Second
 	ReadTimeout    = 30 * time.Second
@@ -97,6 +98,37 @@ func DiscoverInterpreters(host string) ([]string, error) {
 	}
 	interps := strings.Fields(resp)
 	return interps, nil
+}
+
+// SendText sends a command using the text protocol (newline-terminated) on port 4620.
+// Used for %reg and %match commands.
+func SendText(host string, port int, cmd string) (string, error) {
+	addr := fmt.Sprintf("%s:%d", host, port)
+	conn, err := net.DialTimeout("tcp", addr, ConnectTimeout)
+	if err != nil {
+		return "", fmt.Errorf("connection to %s failed: %w", addr, err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(ReadTimeout))
+
+	fmt.Fprintf(conn, "%s\n", cmd)
+
+	buf := make([]byte, 4096)
+	n, _ := conn.Read(buf)
+	return strings.TrimSpace(string(buf[:n])), nil
+}
+
+// GetLocalIP determines our IP address as seen by the dserv host.
+func GetLocalIP(host string) (string, error) {
+	addr := fmt.Sprintf("%s:%d", host, DservTextPort)
+	conn, err := net.DialTimeout("tcp", addr, ConnectTimeout)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	localAddr := conn.LocalAddr().String()
+	ip, _, _ := net.SplitHostPort(localAddr)
+	return ip, nil
 }
 
 // TestConnection verifies dserv is reachable on port 2560.


### PR DESCRIPTION
## Summary
- Add `dservctl listen <pattern>` command for subscribing to real-time datapoint updates via the dserv pub/sub system
- Add text protocol support (`SendText`, `GetLocalIP`) for `%reg`/`%match` commands on port 4620
- Fix tab completion when in stim mode — send `complete_token` directly to STIM (port 4612) instead of routing through the dserv Tcl proxy subprocess

## Usage
```
dservctl listen "ess/*"                    # stream all ess datapoints
dservctl listen "ess/state" "print"        # watch specific patterns
dservctl listen "*"                        # watch everything
dservctl --json listen "ess/*"             # raw JSON output
```

Output format:
```
15:04:05.123  ess/state                       running
15:04:05.456  ess/obs_count                   42
```

## How it works
1. Starts a local TCP listener on a random port
2. Registers with dserv via `%reg <our-ip> <port> 2` (JSON mode) on text port 4620
3. Subscribes to patterns via `%match <our-ip> <port> <pattern> 1`
4. Reads newline-terminated JSON from incoming connections
5. Formats and prints each datapoint update (or passes through raw JSON with `--json`)

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (13 tests)
- [ ] Verify `dservctl listen "ess/*"` receives updates on live system
- [ ] Verify stim tab completion works in shell (`/stim` then Tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)