### PR TITLE
Fix shell interpreter switching in dservctl

### DIFF
--- a/tools/dservctl/shell.go
+++ b/tools/dservctl/shell.go
@@ -148,8 +148,8 @@ func runShell(cfg *Config, args []string) int {
 			}
 		}
 
-		// Send command to current interpreter
-		resp, err := Send(cfg.Host, interp, line)
+		// Send command to current interpreter (completer.interp tracks switches)
+		resp, err := Send(cfg.Host, completer.interp, line)
 		if err != nil {
 			PrintError("%v", err)
 			continue


### PR DESCRIPTION
## Summary
- Fixed a bug where `/stim`, `/ess`, `/db`, etc. in the interactive shell changed the prompt but didn't actually route commands to the new interpreter
- Root cause: `handleMetaCommand()` updated `completer.interp` but the command dispatch loop read from a separate local `interp` variable that never changed
- Fix: command dispatch now reads from `completer.interp` so interpreter switches take effect immediately

## Test plan
- [ ] `dservctl shell` → `/stim` → verify commands go to stim2 (port 4612), not the dserv stim subprocess
- [ ] `/ess` → verify commands route via `send ess {cmd}` through port 2560
- [ ] `/dserv` → verify commands go directly to dserv main interpreter

🤖 Generated with [Claude Code](https://claude.com/claude-code)