### PR TITLE
Add registry URL support, templates seed, and systems delete

### DIFF
--- a/tools/dservctl/agent.go
+++ b/tools/dservctl/agent.go
@@ -27,6 +27,17 @@ func NewAgentClient(cfg *Config) *AgentClient {
 	}
 }
 
+// NewRegistryClient creates an AgentClient pointing at the ESS registry server.
+func NewRegistryClient(cfg *Config) *AgentClient {
+	return &AgentClient{
+		BaseURL: cfg.RegistryBaseURL(),
+		Token:   cfg.Token,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
 // Do performs an HTTP request with auth and returns parsed JSON.
 func (c *AgentClient) Do(method, path string, body interface{}) (map[string]interface{}, error) {
 	url := c.BaseURL + path

--- a/tools/dservctl/cmd_registry.go
+++ b/tools/dservctl/cmd_registry.go
@@ -8,8 +8,12 @@ import (
 	"time"
 )
 
-// runSystems lists ESS systems in a workgroup.
+// runSystems lists ESS systems in a workgroup, or deletes a system.
 func runSystems(cfg *Config, args []string) int {
+	if len(args) > 0 && args[0] == "delete" {
+		return runSystemDelete(cfg, args[1:])
+	}
+
 	wg := cfg.Workgroup
 	if len(args) > 0 {
 		wg = args[0]
@@ -19,7 +23,7 @@ func runSystems(cfg *Config, args []string) int {
 		return 2
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	systems, err := client.ListSystems(wg)
 	if err != nil {
 		PrintError("%v", err)
@@ -61,6 +65,34 @@ func runSystems(cfg *Config, args []string) int {
 	return 0
 }
 
+func runSystemDelete(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl systems delete <system> [--workgroup WG]\n")
+		return 2
+	}
+	if !requireWorkgroup(cfg) {
+		return 2
+	}
+
+	system := args[0]
+
+	client := NewRegistryClient(cfg)
+	result, err := client.DeleteSystem(cfg.Workgroup, system)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	scriptCount := intVal(result, "deletedScripts")
+	fmt.Printf("Deleted system %q from workgroup %q (%d scripts removed)\n", system, cfg.Workgroup, scriptCount)
+	return 0
+}
+
 // runScripts lists scripts for a system grouped by protocol.
 func runScripts(cfg *Config, args []string) int {
 	if len(args) == 0 {
@@ -80,7 +112,7 @@ func runScripts(cfg *Config, args []string) int {
 		}
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.GetScripts(cfg.Workgroup, system, version)
 	if err != nil {
 		PrintError("%v", err)
@@ -185,7 +217,7 @@ func runScriptGet(cfg *Config, args []string) int {
 		}
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.GetScript(cfg.Workgroup, system, protocol, scriptType, version)
 	if err != nil {
 		PrintError("%v", err)
@@ -270,7 +302,7 @@ func runScriptSave(cfg *Config, args []string) int {
 		return 2
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 
 	// Get current checksum for conflict detection
 	expectedChecksum := ""
@@ -324,7 +356,7 @@ func runScriptDelete(cfg *Config, args []string) int {
 
 	system, protocol, scriptType := args[0], args[1], args[2]
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	_, err := client.DeleteScript(cfg.Workgroup, system, protocol, scriptType)
 	if err != nil {
 		PrintError("%v", err)
@@ -347,7 +379,7 @@ func runHistory(cfg *Config, args []string) int {
 
 	system, protocol, scriptType := args[0], args[1], args[2]
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.GetHistory(cfg.Workgroup, system, protocol, scriptType)
 	if err != nil {
 		PrintError("%v", err)
@@ -385,13 +417,16 @@ func runHistory(cfg *Config, args []string) int {
 	return 0
 }
 
-// runTemplates lists or adds templates.
+// runTemplates lists, adds, or seeds templates.
 func runTemplates(cfg *Config, args []string) int {
 	if len(args) > 0 && args[0] == "add" {
 		return runTemplateAdd(cfg, args[1:])
 	}
+	if len(args) > 0 && args[0] == "seed" {
+		return runTemplateSeed(cfg, args[1:])
+	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	templates, err := client.ListTemplates()
 	if err != nil {
 		PrintError("%v", err)
@@ -446,7 +481,7 @@ func runTemplateAdd(cfg *Config, args []string) int {
 
 	templateName := args[0]
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.AddToWorkgroup(templateName, cfg.Workgroup, cfg.User)
 	if err != nil {
 		PrintError("%v", err)
@@ -459,6 +494,44 @@ func runTemplateAdd(cfg *Config, args []string) int {
 	}
 
 	fmt.Printf("Added template %q to workgroup %q\n", templateName, cfg.Workgroup)
+	return 0
+}
+
+func runTemplateSeed(cfg *Config, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: dservctl templates seed <path> [system...]\n")
+		fmt.Fprintf(os.Stderr, "\nSeeds templates from a filesystem directory into the _templates workgroup.\n")
+		fmt.Fprintf(os.Stderr, "If no systems are specified, all found systems are imported.\n")
+		return 2
+	}
+
+	sourcePath := args[0]
+	systems := args[1:]
+
+	client := NewRegistryClient(cfg)
+	result, err := client.SeedTemplates(sourcePath, systems)
+	if err != nil {
+		PrintError("%v", err)
+		return 1
+	}
+
+	if cfg.JSON {
+		printJSON(result)
+		return 0
+	}
+
+	if seeded, ok := result["systems"].([]interface{}); ok && len(seeded) > 0 {
+		names := make([]string, len(seeded))
+		for i, v := range seeded {
+			names[i] = fmt.Sprintf("%v", v)
+		}
+		fmt.Printf("Seeded %d template(s): %s\n", len(names), strings.Join(names, ", "))
+	} else {
+		fmt.Println("No templates seeded.")
+	}
+	if libs, ok := result["libraries"].([]interface{}); ok && len(libs) > 0 {
+		fmt.Printf("Imported %d library/libraries.\n", len(libs))
+	}
 	return 0
 }
 
@@ -497,7 +570,7 @@ func runExport(cfg *Config, args []string) int {
 		}
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	data, err := client.ExportZip(wg, system)
 	if err != nil {
 		PrintError("%v", err)

--- a/tools/dservctl/cmd_sandbox.go
+++ b/tools/dservctl/cmd_sandbox.go
@@ -66,7 +66,7 @@ func runSandboxCreate(cfg *Config, args []string) int {
 		}
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.CreateSandbox(cfg.Workgroup, system, fromVersion, toVersion, cfg.User, comment)
 	if err != nil {
 		PrintError("%v", err)
@@ -125,7 +125,7 @@ func runSandboxPromote(cfg *Config, args []string) int {
 		return 2
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.PromoteSandbox(cfg.Workgroup, system, fromVersion, toVersion, cfg.User, comment)
 	if err != nil {
 		PrintError("%v", err)
@@ -165,7 +165,7 @@ func runSandboxSync(cfg *Config, args []string) int {
 		}
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.SyncSandbox(cfg.Workgroup, system, fromVersion, toVersion, cfg.User)
 	if err != nil {
 		PrintError("%v", err)
@@ -199,7 +199,7 @@ func runSandboxDelete(cfg *Config, args []string) int {
 		return 1
 	}
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	_, err := client.DeleteSandbox(cfg.Workgroup, system, version)
 	if err != nil {
 		PrintError("%v", err)
@@ -226,7 +226,7 @@ func runSandboxVersions(cfg *Config, args []string) int {
 
 	system := args[0]
 
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	result, err := client.ListVersions(cfg.Workgroup, system)
 	if err != nil {
 		PrintError("%v", err)

--- a/tools/dservctl/cmd_sync.go
+++ b/tools/dservctl/cmd_sync.go
@@ -49,7 +49,7 @@ func runSync(cfg *Config, args []string) int {
 	}
 
 	// Step 1: Get manifest from server
-	client := NewAgentClient(cfg)
+	client := NewRegistryClient(cfg)
 	manifest, err := client.GetManifest(cfg.Workgroup, system, version)
 	if err != nil {
 		PrintError("fetching manifest: %v", err)

--- a/tools/dservctl/config.go
+++ b/tools/dservctl/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Token     string // Bearer token for agent API
 	Workgroup string // Default workgroup
 	User      string // Username for registry operations
+	Registry  string // Registry URL (e.g., https://dserv.net)
 	JSON      bool   // JSON output mode
 	Verbose   bool   // Verbose logging
 	Command   string // -c command (single execution)
@@ -89,6 +90,14 @@ func (cfg *Config) ParseFlags(args []string) []string {
 				fmt.Fprintf(os.Stderr, "Error: %s requires a value\n", args[i])
 				os.Exit(2)
 			}
+		case "--registry", "-r":
+			if i+1 < len(args) {
+				cfg.Registry = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: %s requires a value\n", args[i])
+				os.Exit(2)
+			}
 		case "-c":
 			if i+1 < len(args) {
 				cfg.Command = args[i+1]
@@ -155,6 +164,8 @@ func (cfg *Config) loadConfigFile() {
 			cfg.Workgroup = value
 		case "user":
 			cfg.User = value
+		case "registry":
+			cfg.Registry = value
 		}
 	}
 }
@@ -178,9 +189,36 @@ func (cfg *Config) loadEnvVars() {
 	if v := os.Getenv("DSERV_USER"); v != "" {
 		cfg.User = v
 	}
+	if v := os.Getenv("DSERV_REGISTRY"); v != "" {
+		cfg.Registry = v
+	}
 }
 
 // AgentBaseURL returns the base URL for agent HTTP API
 func (cfg *Config) AgentBaseURL() string {
 	return fmt.Sprintf("http://%s:%d", cfg.Host, cfg.AgentPort)
+}
+
+// RegistryBaseURL returns the base URL for the ESS registry API.
+// Uses --registry flag, DSERV_REGISTRY env, config file, or auto-discovers
+// from the ess/registry/url datapoint.
+func (cfg *Config) RegistryBaseURL() string {
+	if cfg.Registry != "" {
+		return strings.TrimRight(cfg.Registry, "/")
+	}
+
+	// Try to discover from dserv datapoint
+	resp, err := SendToDserv(cfg.Host, "dservGet ess/registry/url")
+	if err == nil {
+		resp = strings.TrimSpace(resp)
+		if resp != "" && !strings.HasPrefix(resp, "!") {
+			if cfg.Verbose {
+				fmt.Fprintf(os.Stderr, "Discovered registry URL: %s\n", resp)
+			}
+			return strings.TrimRight(resp, "/")
+		}
+	}
+
+	// Fall back to local agent
+	return cfg.AgentBaseURL()
 }

--- a/tools/dservctl/main.go
+++ b/tools/dservctl/main.go
@@ -31,11 +31,11 @@ func init() {
 		{"service", "Control dserv service (start/stop/restart)", runService},
 		{"components", "List or install components", runComponents},
 		{"logs", "View service logs", runLogs},
-		{"systems", "List ESS systems in workgroup", runSystems},
+		{"systems", "List or delete ESS systems in workgroup", runSystems},
 		{"scripts", "List scripts for a system", runScripts},
 		{"script", "Get or save a script", runScript},
 		{"history", "Show script version history", runHistory},
-		{"templates", "List or add templates", runTemplates},
+		{"templates", "List, add, or seed templates", runTemplates},
 		{"sandbox", "Manage sandboxes (create/promote/sync/delete)", runSandbox},
 		{"export", "Export workgroup or system as ZIP", runExport},
 		{"sync", "Sync scripts with local directory", runSync},
@@ -56,6 +56,7 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  -t, --token TOKEN       Bearer token (env: DSERV_AGENT_TOKEN)\n")
 	fmt.Fprintf(os.Stderr, "  -w, --workgroup WG      Default workgroup (env: DSERV_WORKGROUP)\n")
 	fmt.Fprintf(os.Stderr, "  -u, --user USER         Username for registry ops (env: DSERV_USER)\n")
+	fmt.Fprintf(os.Stderr, "  -r, --registry URL      ESS registry URL (env: DSERV_REGISTRY, or auto-discovered)\n")
 	fmt.Fprintf(os.Stderr, "  --json                  Output JSON\n")
 	fmt.Fprintf(os.Stderr, "  --verbose               Verbose output\n\n")
 	fmt.Fprintf(os.Stderr, "Commands:\n")
@@ -84,6 +85,8 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  dservctl listen \"ess/*\"                       Stream datapoint updates\n")
 	fmt.Fprintf(os.Stderr, "  dservctl script get sys proto type > f.tcl    Download script\n")
 	fmt.Fprintf(os.Stderr, "  dservctl sandbox create sys mybranch          Create sandbox\n")
+	fmt.Fprintf(os.Stderr, "  dservctl templates seed /path/to/systems      Seed templates from filesystem\n")
+	fmt.Fprintf(os.Stderr, "  dservctl systems delete sys                   Delete a system and its scripts\n")
 }
 
 func main() {

--- a/tools/dservctl/registry.go
+++ b/tools/dservctl/registry.go
@@ -186,6 +186,22 @@ func (c *AgentClient) ListVersions(workgroup, system string) (map[string]interfa
 	return c.Get(path)
 }
 
+// SeedTemplates imports systems from a filesystem path into the _templates workgroup.
+func (c *AgentClient) SeedTemplates(sourcePath string, systems []string) (map[string]interface{}, error) {
+	return c.Post(registryBase+"/admin/seed-templates", map[string]interface{}{
+		"sourcePath": sourcePath,
+		"systems":    systems,
+	})
+}
+
+// DeleteSystem removes a system and all its scripts.
+func (c *AgentClient) DeleteSystem(workgroup, system string) (map[string]interface{}, error) {
+	return c.Do("DELETE", registryBase+"/scaffold/system", map[string]string{
+		"workgroup": workgroup,
+		"system":    system,
+	})
+}
+
 // ExportZip downloads a workgroup or system as ZIP.
 func (c *AgentClient) ExportZip(workgroup, system string) ([]byte, error) {
 	path := fmt.Sprintf("%s/export/%s", registryBase, url.PathEscape(workgroup))


### PR DESCRIPTION
## Summary
- Add `--registry` / `-r` flag and `DSERV_REGISTRY` env var to configure the ESS registry server URL separately from the local agent
- Auto-discovers registry URL from the `ess/registry/url` datapoint (same mechanism as the web GUI) when not explicitly set
- All registry commands (`systems`, `scripts`, `templates`, `sandbox`, `sync`, `export`) now target the registry server; agent commands (`status`, `mesh`, `service`, `components`, `logs`) still target the local agent
- Add `templates seed <path> [system...]` to import systems from filesystem into `_templates` workgroup
- Add `systems delete <system>` to remove a system and all its scripts (deleting the last system effectively removes the workgroup)

## Test plan
- [ ] `dservctl templates` lists templates from registry server (no longer 404)
- [ ] `dservctl --registry https://host templates` overrides auto-discovery
- [ ] `dservctl templates seed /path/to/systems` seeds templates from filesystem
- [ ] `dservctl systems delete <sys> -w <wg>` removes a system
- [ ] `dservctl status` still hits local agent (not registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)