### PR TITLE
Add dservctl to CMake build and release workflows

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -97,6 +97,44 @@ jobs:
           generateReleaseNotes: true
           allowUpdates: true
 
+  release-dservctl:
+
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            goarch: amd64
+          - os: ubuntu-22.04-arm
+            goarch: arm64
+
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+
+    steps:
+
+      - name: Check out our dserv code for the current tag.
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build dservctl
+        run: |
+          cd tools/dservctl
+          CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o dservctl_linux_${{ matrix.goarch }} .
+
+      - name: Upload dservctl binary
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "tools/dservctl/dservctl_linux_${{ matrix.goarch }}"
+          body: dserv version ${{ github.ref_name }}
+          generateReleaseNotes: true
+          allowUpdates: true
+
   release-camera:
 
     strategy:

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -131,6 +131,36 @@ jobs:
           echo "return 100" | essctrl
           /usr/local/dserv/dserv --help
 
+  release-dservctl:
+
+    runs-on: macos-14
+
+    permissions:
+      contents: write
+
+    steps:
+
+      - name: Check out our code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build dservctl
+        run: |
+          cd tools/dservctl
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dservctl_darwin_arm64 .
+
+      - name: Upload dservctl binary
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "tools/dservctl/dservctl_darwin_arm64"
+          body: dserv version ${{ github.ref_name }}
+          generateReleaseNotes: true
+          allowUpdates: true
+
   release-essgui:
 
     # Build on not-the-latest to keep dependency versions modest.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,47 @@ else()
     set(DSERV_AGENT_FOUND FALSE)
 endif()
 
+# ============================================================================
+# dservctl (Go-based CLI tool)
+# ============================================================================
+if(GO_EXECUTABLE)
+    set(DSERVCTL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tools/dservctl)
+    set(DSERVCTL_BINARY ${CMAKE_CURRENT_BINARY_DIR}/bin/dservctl)
+
+    if(EXISTS ${DSERVCTL_SOURCE_DIR}/main.go)
+        message(STATUS "Found dservctl source at ${DSERVCTL_SOURCE_DIR}")
+
+        # Collect Go source files that should trigger rebuild
+        file(GLOB DSERVCTL_GO_SOURCES ${DSERVCTL_SOURCE_DIR}/*.go)
+
+        add_custom_command(
+            OUTPUT ${DSERVCTL_BINARY}
+            COMMAND ${CMAKE_COMMAND} -E env
+                GOOS=${GOOS}
+                GOARCH=${GOARCH}
+                CGO_ENABLED=0
+                ${GO_EXECUTABLE} build -o ${DSERVCTL_BINARY} .
+            WORKING_DIRECTORY ${DSERVCTL_SOURCE_DIR}
+            DEPENDS ${DSERVCTL_GO_SOURCES}
+            COMMENT "Building dservctl for ${GOOS}/${GOARCH}"
+            VERBATIM
+        )
+
+        add_custom_target(dservctl ALL DEPENDS ${DSERVCTL_BINARY})
+
+        install(PROGRAMS ${DSERVCTL_BINARY}
+            DESTINATION bin
+            COMPONENT dservctl
+        )
+
+        set(DSERVCTL_FOUND TRUE)
+    else()
+        message(STATUS "dservctl source not found at ${DSERVCTL_SOURCE_DIR}")
+        set(DSERVCTL_FOUND FALSE)
+    endif()
+else()
+    set(DSERVCTL_FOUND FALSE)
+endif()
 
 install(TARGETS dserv DESTINATION dserv COMPONENT dserv)
 install(DIRECTORY config DESTINATION dserv COMPONENT dserv)
@@ -416,7 +457,10 @@ elseif(APPLE)
     if(DSERV_AGENT_FOUND)
        list(APPEND CPACK_COMPONENTS_ALL dserv-agent)
     endif()
-    
+    if(DSERVCTL_FOUND)
+       list(APPEND CPACK_COMPONENTS_ALL dservctl)
+    endif()
+
     if(DEFINED CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM)
         # Configure for apple code signing, notarization, and gatekeeper/entitlements.
         set(CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS "--strict --timestamp --options=runtime")
@@ -453,4 +497,7 @@ include(CPack)
 cpack_add_component(dserv essctrl REQUIRED)
 if(DSERV_AGENT_FOUND)
     cpack_add_component(dserv-agent)
+endif()
+if(DSERVCTL_FOUND)
+    cpack_add_component(dservctl)
 endif()


### PR DESCRIPTION
## Summary
- Add dservctl as a CMake build target following the same pattern as dserv-agent (Go custom command/target, installed to `bin/`, included in macOS .pkg)
- Add `release-dservctl` job to Linux release workflow — builds standalone binaries for amd64 and arm64
- Add `release-dservctl` job to macOS release workflow — builds standalone arm64 binary

Release artifacts will include:
- `dservctl_linux_amd64` and `dservctl_linux_arm64` (standalone binaries)
- `dservctl_darwin_arm64` (standalone binary)
- dservctl included in the macOS signed `.pkg` installer

## Test plan
- [x] `cmake -B build && cmake --build build --target dservctl` produces `build/bin/dservctl`
- [ ] Next tagged release should produce dservctl binaries in GitHub release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)