### PR TITLE
Default to interactive shell when essctrl invoked with no args

### DIFF
--- a/tools/dservctl/essctrl.go
+++ b/tools/dservctl/essctrl.go
@@ -93,9 +93,11 @@ func runEssctrl(cfg *Config) int {
 		return essctrlStdin(cfg.Host, port, service)
 	}
 
-	// No command, no stdin — print usage (no interactive mode)
-	printEssctrlUsage()
-	return 0
+	// No command, no stdin — launch interactive shell
+	if service != "" && service != "ess" {
+		return runShell(cfg, []string{"-s", service})
+	}
+	return runShell(cfg, nil)
 }
 
 // essctrlSend sends a single command via the appropriate protocol.


### PR DESCRIPTION
## Summary
- When invoked as `essctrl` with no arguments, launch interactive shell instead of printing help
- Matches original C essctrl behavior
- The `-s service` flag is passed through to the shell for targeting specific interpreters

## Test plan
- [x] `./essctrl` (no args) launches interactive shell
- [x] `./essctrl -s db` launches shell targeting db interpreter
- [x] `./essctrl -c "return 100"` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)