### PR TITLE
use a callable function for setting audio volume so tasks can set it

### DIFF
--- a/lib/ess-2.0.tm
+++ b/lib/ess-2.0.tm
@@ -4456,6 +4456,12 @@ namespace eval ess {
     proc sound_set_volume { volume channel } {
 		send sound "soundVolume $volume $channel"
     }
+    # Master loudness (MIDI CC7, 0-127) on the standard feedback channels.
+    proc sound_set_master_volume { volume } {
+		foreach i {0 1 2 3 4 5 6} {
+			sound_set_volume $volume $i
+		}
+    }
     proc sound_init {} {
 		sound_reset
 		sound_set_voice 81 0 0
@@ -4465,7 +4471,7 @@ namespace eval ess {
 		sound_set_voice 21 0 4
 		sound_set_voice 8 0 5
 		sound_set_voice 113 100 6
-		foreach i "0 1 2 3 4 5 6" { sound_set_volume 127 $i }
+		sound_set_master_volume 127
     }
 }
 


### PR DESCRIPTION
to add to task:

1. Add the param (next to juice_ml)
$s add_param sound_volume 0 variable int   ;# or 100 if you want it on by default
2. Apply after sound init
::ess::sound_init
::ess::sound_set_master_volume $sound_volume
3. Apply again before every play site
So mid-session GUI tweaks work (same idea as juice_ml):

$s add_method prestim {} {
    ::ess::sound_set_master_volume $sound_volume
    ::ess::sound_play 1 70 200
}
$s add_method reward {} {
    ::ess::sound_set_master_volume $sound_volume
    ::ess::sound_play 3 70 70
    ...
}
$s add_method finale {} {
    ::ess::sound_set_master_volume $sound_volume
    ::ess::sound_play 6 60 400
}
Do that for every method/action that calls ::ess::sound_play (prestim, fixon, noreward buzz, letgo warning, etc.).

If sound is played from the system file (e.g. MTS/planko letgo_sound), either:

add $sys add_param sound_volume 0 variable int on the system, and wrap that play the same way, or
rely on the protocol param (same variable name on the state system) and still wrap the system play site.